### PR TITLE
fix/19: remove unreachable condition

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Newss/GetNewsAndLinksByUrl/GetNewsAndLinksByUrlHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Newss/GetNewsAndLinksByUrl/GetNewsAndLinksByUrlHandler.cs
@@ -87,13 +87,6 @@ namespace Streetcode.BLL.MediatR.Newss.GetNewsAndLinksByUrl
             newsDTOWithUrls.NextNewsUrl = nextNewsLink;
             newsDTOWithUrls.PrevNewsUrl = prevNewsLink;
 
-            if (newsDTOWithUrls is null)
-            {
-                string errorMsg = $"No news by entered Url - {url}";
-                _logger.LogError(request, errorMsg);
-                return Result.Fail(errorMsg);
-            }
-
             return Result.Ok(newsDTOWithUrls);
         }
     }


### PR DESCRIPTION
Since the newsDTOWithUrls object is created directly before the null check, it can never be null.

dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
