### PR TITLE
fix/27: Fix deprecated RecurringJob.AddOrUpdate method and update timezone handling

### DIFF
--- a/Streetcode/Streetcode.WebApi/Program.cs
+++ b/Streetcode/Streetcode.WebApi/Program.cs
@@ -42,10 +42,18 @@ if (app.Environment.EnvironmentName != "Local")
 {
     BackgroundJob.Schedule<WebParsingUtils>(
     wp => wp.ParseZipFileFromWebAsync(), TimeSpan.FromMinutes(1));
+
     RecurringJob.AddOrUpdate<WebParsingUtils>(
-        wp => wp.ParseZipFileFromWebAsync(), Cron.Monthly);
+        "ParseZipFileFromWeb_Monthly",
+        wp => wp.ParseZipFileFromWebAsync(),
+        Cron.Monthly,
+        new RecurringJobOptions { TimeZone = TimeZoneInfo.FindSystemTimeZoneById("FLE Standard Time") });
+
     RecurringJob.AddOrUpdate<BlobService>(
-        b => b.CleanBlobStorage(), Cron.Monthly);
+        "CleanBlobStorage_Monthly",
+        b => b.CleanBlobStorage(),
+        Cron.Monthly,
+        new RecurringJobOptions { TimeZone = TimeZoneInfo.FindSystemTimeZoneById("FLE Standard Time") });
 }
 
 app.MapControllers();


### PR DESCRIPTION
- Fix deprecated RecurringJob.AddOrUpdate method having used an overload with the explicit recurringJobId parameter and RecurringJobOptions

- Update timezone handling to Kyiv

dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
