### PR TITLE
fix/20: fix bug with DistinctBy in MediatR/Toponyms/GetByStreetcodeId

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Toponyms/GetByStreetcodeId/GetToponymsByStreetcodeIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Toponyms/GetByStreetcodeId/GetToponymsByStreetcodeIdHandler.cs
@@ -38,8 +38,8 @@ public class GetToponymsByStreetcodeIdHandler : IRequestHandler<GetToponymsByStr
             return Result.Fail(new Error(errorMsg));
         }
 
-        toponyms.DistinctBy(x => x.StreetName);
-        var toponymDto = toponyms.GroupBy(x => x.StreetName).Select(group => group.First()).Select(x => _mapper.Map<ToponymDTO>(x));
+        var filteredToponyms = toponyms.DistinctBy(x => x.StreetName);
+        var toponymDto = filteredToponyms.GroupBy(x => x.StreetName).Select(group => group.First()).Select(x => _mapper.Map<ToponymDTO>(x));
         return Result.Ok(toponymDto);
     }
 }


### PR DESCRIPTION
Fixed not using the return value of DistinctBy bug in MediatR/Toponyms/GetByStreetcodeId