### PR TITLE
 feat/SSAD-148: Added text creation feature with validation and tests

### DIFF
--- a/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Text/TextCreateDTO.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Text/TextCreateDTO.cs
@@ -5,5 +5,6 @@ namespace Streetcode.BLL.DTO.Streetcode.TextContent.Text
     public string Title { get; set; }
     public string TextContent { get; set; }
     public string? AdditionalText { get; set; }
-  }
+    public int StreetcodeId { get; set; }
+    }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Create/CreateTextCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Create/CreateTextCommand.cs
@@ -1,0 +1,8 @@
+﻿using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Text.Create
+{
+    public record CreateTextCommand(TextCreateDTO TextCreateDto) : IRequest<Result<TextDTO>>;
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Create/CreateTextCommandValidator.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Create/CreateTextCommandValidator.cs
@@ -1,0 +1,42 @@
+﻿using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Text.Create
+{
+    public class CreateTextCommandValidator : AbstractValidator<CreateTextCommand>
+    {
+        private const int TitleMaxLength = 300;
+        private const int TextContentMaxLength = 15000;
+        private const int AdditionalTextMaxLength = 200;
+
+        public CreateTextCommandValidator()
+        {
+            RuleFor(x => x.TextCreateDto.Title)
+             .NotEmpty()
+             .WithMessage("Text title is required")
+             .MaximumLength(TitleMaxLength)
+             .WithMessage($"Text title must not exceed {TitleMaxLength} chars");
+
+            RuleFor(x => x.TextCreateDto.TextContent)
+                .NotEmpty()
+                .WithMessage("Text content is required")
+                .MaximumLength(TextContentMaxLength)
+                .WithMessage($"Text content must not exceed {TextContentMaxLength} chars");
+
+            RuleFor(x => x.TextCreateDto.AdditionalText)
+                .NotEmpty()
+                .WithMessage("Text additional text is required")
+                .MaximumLength(AdditionalTextMaxLength)
+                .WithMessage($"Text additional text must not exceed {AdditionalTextMaxLength} chars");
+
+            RuleFor(x => x.TextCreateDto.StreetcodeId)
+                .GreaterThan(0)
+                .WithMessage("Text StreetcodeId must be > 0");
+        }
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Create/CreateTextHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Create/CreateTextHandler.cs
@@ -1,0 +1,54 @@
+﻿using AutoMapper;
+using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+using Streetcode.BLL.Exceptions;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.Specifications.Streetcode.Streetcode;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Text.Create
+{
+    public class CreateTextHandler : IRequestHandler<CreateTextCommand, Result<TextDTO>>
+    {
+        private readonly IRepositoryWrapper _repository;
+        private readonly IMapper _mapper;
+        private readonly ILoggerService _logger;
+        public CreateTextHandler(IRepositoryWrapper resitoryWrapper, IMapper mapper, ILoggerService loggerService)
+        {
+            _logger = loggerService;
+            _mapper = mapper;
+            _repository = resitoryWrapper;
+        }
+
+        public async Task<Result<TextDTO>> Handle(CreateTextCommand request, CancellationToken cancellationToken)
+        {
+            var streetcodeExists = await _repository.StreetcodeRepository.GetFirstOrDefaultBySpecAsync(new GetByStreetcodeIdSpecification(request.TextCreateDto.StreetcodeId));
+            if (streetcodeExists == null)
+            {
+                const string errorMessage = "Streetcode does not exist.";
+                _logger.LogError(request, errorMessage);
+                throw new EntityNotFoundException();
+            }
+
+            var newText = _mapper.Map<DAL.Entities.Streetcode.TextContent.Text>(request.TextCreateDto);
+            if (newText == null)
+            {
+                const string errorMessage = "Failed to map our DTO to TextDTO.";
+                _logger.LogError(request, errorMessage);
+                throw new Exception(errorMessage);
+            }
+
+            var createdText = await _repository.TextRepository.CreateAsync(newText);
+            var isSucess = await _repository.SaveChangesAsync();
+            if (isSucess == 0)
+            {
+                const string errorMessage = "Failed to save changes to the database.";
+                _logger.LogError(request, errorMessage);
+                throw new Exception(errorMessage);
+            }
+
+            return Result.Ok(_mapper.Map<TextDTO>(createdText));
+        }
+    }
+}

--- a/Streetcode/Streetcode.BLL/Specifications/Streetcode/Streetcode/GetByStreetcodeIdSpecification.cs
+++ b/Streetcode/Streetcode.BLL/Specifications/Streetcode/Streetcode/GetByStreetcodeIdSpecification.cs
@@ -1,0 +1,18 @@
+﻿using Streetcode.DAL.Entities.Streetcode;
+using Streetcode.DAL.Specification;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Streetcode.BLL.Specifications.Streetcode.Streetcode
+{
+    public class GetByStreetcodeIdSpecification : BaseSpecification<StreetcodeContent>
+    {
+        public GetByStreetcodeIdSpecification(int streetcodeId)
+            : base(id => id.Id == streetcodeId)
+        {
+        }
+    }
+}

--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/TextController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/TextController.cs
@@ -1,6 +1,8 @@
 using FluentResults;
 using Microsoft.AspNetCore.Mvc;
 using Streetcode.BLL.DTO.Streetcode.TextContent;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+using Streetcode.BLL.MediatR.Streetcode.Text.Create;
 using Streetcode.BLL.MediatR.Streetcode.Text.GetAll;
 using Streetcode.BLL.MediatR.Streetcode.Text.GetById;
 using Streetcode.BLL.MediatR.Streetcode.Text.GetByStreetcodeId;
@@ -32,5 +34,11 @@ public class TextController : BaseApiController
     public async Task<IActionResult> GetParsedText([FromQuery] string text)
     {
         return HandleResult(await Mediator.Send(new GetParsedTextForAdminPreviewQuery(text)));
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] TextCreateDTO text)
+    {
+        return HandleResult(await Mediator.Send(new CreateTextCommand(text)));
     }
 }

--- a/Streetcode/Streetcode.WebApi/Program.cs
+++ b/Streetcode/Streetcode.WebApi/Program.cs
@@ -29,7 +29,7 @@ else
 await app.ApplyMigrations();
 
 // func to seed data
-await app.SeedDataAsync();
+// await app.SeedDataAsync();
 app.UseCors();
 
 app.UseHttpsRedirection();

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Streetcode/Text/Create/CreateTextHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Streetcode/Text/Create/CreateTextHandlerTests.cs
@@ -1,0 +1,129 @@
+﻿using AutoMapper;
+using FluentAssertions;
+using Moq;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+using Streetcode.BLL.Exceptions;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.Mapping.Streetcode.TextContent;
+using Streetcode.BLL.MediatR.Streetcode.Text.Create;
+using Streetcode.BLL.Specifications.Streetcode.Streetcode;
+using Streetcode.DAL.Entities.Streetcode;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Xunit;
+using TextEntity = Streetcode.DAL.Entities.Streetcode.TextContent.Text;
+
+namespace Streetcode.XUnitTest.MediatRTests.Streetcode.Text.Create
+{
+    public class CreateTextHandlerTests
+    {
+        private readonly IMapper _mapper;
+        private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+        private readonly Mock<ILoggerService> _mockLogger;
+        private readonly CreateTextHandler _handler;
+
+        public CreateTextHandlerTests()
+        {
+            _mockLogger = new Mock<ILoggerService>();
+            _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+            var configuration = new MapperConfiguration(cfg =>
+            {
+                cfg.AddProfile(typeof(TextProfile));
+            });
+            _mapper = configuration.CreateMapper();
+            _handler = new CreateTextHandler(_mockRepositoryWrapper.Object, _mapper, _mockLogger.Object);
+        }
+
+        [Fact]
+        public async Task Handle_WhenStreetcodeDoesNotExist_ThrowsEntityNotFoundException()
+        {
+            ConfigureStreetcodeRepository(null);
+            var textDTO = CreateTextDTO();
+
+            var command = new CreateTextCommand(textDTO);
+
+            await Assert.ThrowsAsync<EntityNotFoundException>(() => _handler.Handle(command, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task Handle_FailedSaveChanges_ShouldThrowException()
+        {
+            var textDTO = CreateTextDTO();
+            var streetcodeContent = CreateStreetcodeContent();
+
+            ConfigureTextRepository(textDTO);
+            ConfigureStreetcodeRepository(streetcodeContent);
+            ConfigureSaveChanges(0);
+
+            var command = new CreateTextCommand(textDTO);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<Exception>(() =>
+                _handler.Handle(command, CancellationToken.None));
+            _mockLogger.Verify(logger => logger.LogError(It.IsAny<object>(), "Failed to save changes to the database."), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_SuccessfulExecution_ShouldReturnOkResult()
+        {
+            // Arrange
+            var textDTO = CreateTextDTO();
+            var streetcodeContent = CreateStreetcodeContent();
+
+            ConfigureTextRepository(textDTO);
+            ConfigureStreetcodeRepository(streetcodeContent);
+            ConfigureSaveChanges(1);
+
+            var command = new CreateTextCommand(textDTO);
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Value.Should().NotBeNull();
+            result.Value.Title.Should().Be(textDTO.Title);
+
+            _mockLogger.Verify(logger => logger.LogError(It.IsAny<object>(), It.IsAny<string>()), Times.Never);
+        }
+
+        private void ConfigureStreetcodeRepository(StreetcodeContent? streetcodeContent)
+        {
+            _mockRepositoryWrapper.Setup(repo => repo.StreetcodeRepository
+                .GetFirstOrDefaultBySpecAsync(It.IsAny<GetByStreetcodeIdSpecification>()))
+                .ReturnsAsync(streetcodeContent);
+        }
+
+        private void ConfigureTextRepository(TextCreateDTO? text)
+        {
+            _mockRepositoryWrapper.Setup(repo => repo.TextRepository.CreateAsync(It.IsAny<TextEntity>()))
+                .ReturnsAsync(_mapper.Map<TextEntity>(text));
+        }
+
+        private void ConfigureSaveChanges(int isSucess)
+        {
+            _mockRepositoryWrapper.Setup(repo => repo.SaveChangesAsync())
+                .ReturnsAsync(isSucess);
+        }
+
+        private TextCreateDTO CreateTextDTO()
+        {
+            var textCreateDto = new TextCreateDTO
+            {
+                StreetcodeId = 1,
+                Title = "Title to create",
+                TextContent = "Content to create"
+            };
+            return textCreateDto;
+        }
+
+        private StreetcodeContent CreateStreetcodeContent()
+        {
+            var streetcodeContent = new StreetcodeContent
+            {
+                Id = 1,
+                Title = "Title",
+            };
+            return streetcodeContent;
+        }
+    }
+}


### PR DESCRIPTION
- Modified `TextCreateDTO` to include `StreetcodeId` property.
- Added `CreateTextCommand`, `CreateTextCommandValidator`, and `CreateTextHandler` for handling text creation.
- Implemented `Create` method in `TextController` to handle POST requests.
- Added `GetByStreetcodeIdSpecification` for fetching streetcode content by ID.
- Commented out `SeedDataAsync` call in `Program.cs`.
- Added unit tests for `CreateTextHandler` to cover various scenarios.