### PR TITLE
fix/SSAD-197: fix database error via seeding data

### DIFF
--- a/Streetcode/Streetcode.WebApi/Extensions/SeedingLocalExtension.cs
+++ b/Streetcode/Streetcode.WebApi/Extensions/SeedingLocalExtension.cs
@@ -1257,24 +1257,28 @@ namespace Streetcode.WebApi.Extensions
                                         {
                                             Text = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
                                             SourceLinkCategoryId = 1,
+                                            Title = "Random title 1",
                                             StreetcodeId = 2
                                         },
                                         new StreetcodeCategoryContent
                                         {
                                             Text = "Хроніки про Т. Г. Шевченко",
                                             SourceLinkCategoryId = 2,
+                                            Title = "Random title 2",
                                             StreetcodeId = 2
                                         },
                                         new StreetcodeCategoryContent
                                         {
                                             Text = "Цитати про Шевченка",
                                             SourceLinkCategoryId = 3,
+                                            Title = "Random title 3",
                                             StreetcodeId = 2
                                         },
                                         new StreetcodeCategoryContent
                                         {
                                             Text = "Пряма мова",
                                             SourceLinkCategoryId = 3,
+                                            Title = "Random title 4",
                                             StreetcodeId = 1
                                         });
 


### PR DESCRIPTION
Added a new Title property to several instances of the StreetcodeCategoryContent class in SeedingLocalExtension.cs. Each instance now includes a Title field with a corresponding string value.

dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
