### PR TITLE
[User/Commenting on Streetcode] GetByStreetcodeId Comments

### DIFF
--- a/Streetcode/Streetcode.BLL/DTO/Comment/GetCommentDto.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Comment/GetCommentDto.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Streetcode.BLL.DTO.Comment
+{
+    public class GetCommentDto
+    {
+        public int Id { get; set; }
+        public string UserName { get; set; } = null!;
+        public string UserFullName { get; set; } = null!;
+        public DateTime CreatedDate { get; set; }
+        public DateTime? DateModified { get; set; }
+        public string Content { get; set; } = null!;
+        public int StreetcodeId { get; set; }
+        public int? ParentId { get; set; }
+        public List<GetCommentDto>? Children { get; set; }
+    }
+}

--- a/Streetcode/Streetcode.BLL/Mapping/Comment/CommentProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Comment/CommentProfile.cs
@@ -1,0 +1,23 @@
+﻿using AutoMapper;
+using Streetcode.BLL.DTO.Analytics;
+using Streetcode.BLL.DTO.Comment;
+using Streetcode.DAL.Entities.Analytics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommentEntity = Streetcode.DAL.Entities.Comment.Comment;
+
+namespace Streetcode.BLL.Mapping.Comment
+{
+    public class CommentProfile : Profile
+    {
+        public CommentProfile()
+        {
+            // Map from Comment to GetCommentDto
+            CreateMap<CommentEntity, GetCommentDto>()
+                .ForMember(dest => dest.Children, opt => opt.MapFrom(src => src.Children));
+        }
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Comment/GetCommentsByStreetcodeId/GetCommentsByStreetcodeIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Comment/GetCommentsByStreetcodeId/GetCommentsByStreetcodeIdHandler.cs
@@ -1,0 +1,57 @@
+﻿using AutoMapper;
+using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Comment;
+using Streetcode.BLL.DTO.Streetcode.TextContent;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.MediatR.Streetcode.RelatedTerm.GetAllByTermId;
+using Streetcode.BLL.Resources;
+using Streetcode.BLL.Specifications.Comment;
+using Streetcode.BLL.Specifications.Streetcode.RelatedTerm;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Streetcode.BLL.MediatR.Comment.GetCommentsByStreetcodeId
+{
+    public record GetCommentsByStreetcodeIdHandler : IRequestHandler<GetCommentsByStreetcodeIdQuery, Result<IEnumerable<GetCommentDto>>>
+    {
+        private readonly IMapper _mapper;
+        private readonly IRepositoryWrapper _repository;
+        private readonly ILoggerService _logger;
+
+        public GetCommentsByStreetcodeIdHandler(IMapper mapper, IRepositoryWrapper repositoryWrapper, ILoggerService logger)
+        {
+            _mapper = mapper;
+            _repository = repositoryWrapper;
+            _logger = logger;
+        }
+
+        public async Task<Result<IEnumerable<GetCommentDto>>> Handle(GetCommentsByStreetcodeIdQuery request, CancellationToken cancellationToken)
+        {
+            var comments = await _repository.CommentRepository
+                .GetAllBySpecAsync(new CommentByStreetcodeIdSpecification(request.id));
+
+            if (comments is null)
+            {
+                string errorMsg = ErrorManager.GetCustomErrorText("CantFindByStreetcodeIdError", "comment", request.id);
+                _logger.LogError(request, errorMsg);
+                return new Error(errorMsg);
+            }
+
+            var commentsDtos = _mapper.Map<IEnumerable<GetCommentDto>>(comments);
+
+            if (commentsDtos is null)
+            {
+                string errorMsg = ErrorManager.GetCustomErrorText("CantFindError", "DTOS for comments");
+                _logger.LogError(request, errorMsg);
+                return new Error(errorMsg);
+            }
+
+            return Result.Ok(commentsDtos);
+        }
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Comment/GetCommentsByStreetcodeId/GetCommentsByStreetcodeIdQuery.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Comment/GetCommentsByStreetcodeId/GetCommentsByStreetcodeIdQuery.cs
@@ -1,0 +1,16 @@
+﻿using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Comment;
+using Streetcode.BLL.DTO.Streetcode.TextContent;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Streetcode.BLL.MediatR.Comment.GetCommentsByStreetcodeId
+{
+    public record GetCommentsByStreetcodeIdQuery(int id) : IRequest<Result<IEnumerable<GetCommentDto>>>
+    {
+    }
+}

--- a/Streetcode/Streetcode.BLL/Specifications/Comment/CommentByStreetcodeIdSpecification.cs
+++ b/Streetcode/Streetcode.BLL/Specifications/Comment/CommentByStreetcodeIdSpecification.cs
@@ -1,0 +1,21 @@
+﻿using Streetcode.DAL.Specification;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommentEntity = Streetcode.DAL.Entities.Comment.Comment;
+
+namespace Streetcode.BLL.Specifications.Comment
+{
+    public class CommentByStreetcodeIdSpecification : BaseSpecification<CommentEntity>
+    {
+        public CommentByStreetcodeIdSpecification(int id)
+            : base(rt => rt.StreetcodeId == id && rt.ParentId == null)
+        {
+            AddInclude(rt => rt.Children!);
+            AddCaching($"Comments-StreetcodeContent-Id{id}");
+            AddCachingTime(1);
+        }
+    }
+}

--- a/Streetcode/Streetcode.DAL/Entities/Comment/Comment.cs
+++ b/Streetcode/Streetcode.DAL/Entities/Comment/Comment.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Streetcode.DAL.Entities.Streetcode;
+
+namespace Streetcode.DAL.Entities.Comment
+{
+    public class Comment
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+        [Required]
+        [MaxLength(50)]
+        public string UserName { get; set; } = null!;
+        [Required]
+        [MaxLength(100)]
+        public string UserFullName { get; set; } = null!;
+        public DateTime CreatedDate { get; set; }
+        public DateTime? DateModified { get; set; }
+        [Required]
+        [MaxLength(500)]
+        public string Content { get; set; } = null!;
+        [Required]
+        public int StreetcodeId { get; set; }
+        public StreetcodeContent Streetcode { get; set; } = null!;
+        public int? ParentId { get; set; }
+        public Comment? Parent { get; set; }
+        public List<Comment>? Children { get; set; }
+    }
+}

--- a/Streetcode/Streetcode.DAL/Entities/Streetcode/StreetcodeContent.cs
+++ b/Streetcode/Streetcode.DAL/Entities/Streetcode/StreetcodeContent.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Streetcode.DAL.Entities.AdditionalContent;
 using Streetcode.DAL.Entities.AdditionalContent.Coordinates.Types;
 using Streetcode.DAL.Entities.Analytics;
+using CommentEntity = Streetcode.DAL.Entities.Comment.Comment;
 using Streetcode.DAL.Entities.Media;
 using Streetcode.DAL.Entities.Media.Images;
 using Streetcode.DAL.Entities.Partners;
@@ -97,5 +98,7 @@ namespace Streetcode.DAL.Entities.Streetcode
         public List<StreetcodeArt> StreetcodeArts { get; set; } = new();
 
         public List<StreetcodeCategoryContent> StreetcodeCategoryContents { get; set; } = new();
+
+        public List<CommentEntity> Comments { get; set; } = new();
     }
 }

--- a/Streetcode/Streetcode.DAL/Persistence/Configurations/Comment/CommentConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Configurations/Comment/CommentConfiguration.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Streetcode.DAL.Entities.Streetcode;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommentEntity = Streetcode.DAL.Entities.Comment.Comment;
+
+namespace Streetcode.DAL.Persistence.Configurations.Comment
+{
+    public class CommentConfiguration : IEntityTypeConfiguration<CommentEntity>
+    {
+        public void Configure(EntityTypeBuilder<CommentEntity> builder)
+        {
+            builder.HasOne(c => c.Parent)
+                .WithMany(c => c.Children)
+                .HasForeignKey(c => c.ParentId);
+
+            builder.HasOne(c => c.Streetcode)
+                .WithMany(c => c.Comments)
+                .HasForeignKey(c => c.StreetcodeId);
+        }
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Migrations/20241226152519_AddedCommentEntity.Designer.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Migrations/20241226152519_AddedCommentEntity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Streetcode.DAL.Persistence;
 
@@ -11,9 +12,11 @@ using Streetcode.DAL.Persistence;
 namespace Streetcode.DAL.Persistence.Migrations
 {
     [DbContext(typeof(StreetcodeDbContext))]
-    partial class StreetcodeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241226152519_AddedCommentEntity")]
+    partial class AddedCommentEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -163,7 +166,7 @@ namespace Streetcode.DAL.Persistence.Migrations
                     b.Property<DateTime>("CreatedDate")
                         .HasColumnType("datetime2");
 
-                    b.Property<DateTime?>("DateModified")
+                    b.Property<DateTime>("DateModified")
                         .HasColumnType("datetime2");
 
                     b.Property<int?>("ParentId")

--- a/Streetcode/Streetcode.DAL/Persistence/Migrations/20241226152519_AddedCommentEntity.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Migrations/20241226152519_AddedCommentEntity.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Streetcode.DAL.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddedCommentEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Comments",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserName = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    UserFullName = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DateModified = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Content = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: false),
+                    StreetcodeId = table.Column<int>(type: "int", nullable: false),
+                    ParentId = table.Column<int>(type: "int", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Comments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Comments_Comments_ParentId",
+                        column: x => x.ParentId,
+                        principalTable: "Comments",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_Comments_streetcodes_StreetcodeId",
+                        column: x => x.StreetcodeId,
+                        principalSchema: "streetcode",
+                        principalTable: "streetcodes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Comments_ParentId",
+                table: "Comments",
+                column: "ParentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Comments_StreetcodeId",
+                table: "Comments",
+                column: "StreetcodeId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Comments");
+        }
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Migrations/20241226152931_ChangedDateModifiedFieldToNullableInCommentEntity.Designer.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Migrations/20241226152931_ChangedDateModifiedFieldToNullableInCommentEntity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Streetcode.DAL.Persistence;
 
@@ -11,9 +12,11 @@ using Streetcode.DAL.Persistence;
 namespace Streetcode.DAL.Persistence.Migrations
 {
     [DbContext(typeof(StreetcodeDbContext))]
-    partial class StreetcodeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241226152931_ChangedDateModifiedFieldToNullableInCommentEntity")]
+    partial class ChangedDateModifiedFieldToNullableInCommentEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Streetcode/Streetcode.DAL/Persistence/Migrations/20241226152931_ChangedDateModifiedFieldToNullableInCommentEntity.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Migrations/20241226152931_ChangedDateModifiedFieldToNullableInCommentEntity.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Streetcode.DAL.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangedDateModifiedFieldToNullableInCommentEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "DateModified",
+                table: "Comments",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "DateModified",
+                table: "Comments",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+        }
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/StreetcodeDbContext.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/StreetcodeDbContext.cs
@@ -4,6 +4,7 @@ using Streetcode.DAL.Entities.AdditionalContent;
 using Streetcode.DAL.Entities.AdditionalContent.Coordinates;
 using Streetcode.DAL.Entities.AdditionalContent.Coordinates.Types;
 using Streetcode.DAL.Entities.Analytics;
+using Streetcode.DAL.Entities.Comment;
 using Streetcode.DAL.Entities.Feedback;
 using Streetcode.DAL.Entities.Media;
 using Streetcode.DAL.Entities.Media.Images;
@@ -71,6 +72,7 @@ namespace Streetcode.DAL.Persistence
         public DbSet<HistoricalContextTimeline> HistoricalContextsTimelines { get; set; }
         public DbSet<StreetcodePartner> StreetcodePartners { get; set; }
         public DbSet<TeamMemberPositions> TeamMemberPosition { get; set; }
+        public DbSet<Comment> Comments { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/Streetcode/Streetcode.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/Streetcode/Streetcode.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -2,6 +2,7 @@ using System.Transactions;
 using Repositories.Interfaces;
 using Streetcode.DAL.Repositories.Interfaces.AdditionalContent;
 using Streetcode.DAL.Repositories.Interfaces.Analytics;
+using Streetcode.DAL.Repositories.Interfaces.Comment;
 using Streetcode.DAL.Repositories.Interfaces.Media.Images;
 using Streetcode.DAL.Repositories.Interfaces.Newss;
 using Streetcode.DAL.Repositories.Interfaces.Partners;
@@ -52,6 +53,7 @@ public interface IRepositoryWrapper
     IHistoricalContextTimelineRepository HistoricalContextTimelineRepository { get; }
     IStreetcodeToponymRepository StreetcodeToponymRepository { get; }
     IStreetcodeImageRepository StreetcodeImageRepository { get; }
+    ICommentRepository CommentRepository { get; }
     public int SaveChanges();
     public Task<int> SaveChangesAsync();
     public TransactionScope BeginTransaction();

--- a/Streetcode/Streetcode.DAL/Repositories/Interfaces/Comment/ICommentRepository.cs
+++ b/Streetcode/Streetcode.DAL/Repositories/Interfaces/Comment/ICommentRepository.cs
@@ -1,0 +1,16 @@
+﻿using Streetcode.DAL.Entities.Analytics;
+using Streetcode.DAL.Entities.Comment;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommentEntity = Streetcode.DAL.Entities.Comment.Comment;
+
+namespace Streetcode.DAL.Repositories.Interfaces.Comment
+{
+    public interface ICommentRepository : IRepositoryBase<CommentEntity>
+    {
+    }
+}

--- a/Streetcode/Streetcode.DAL/Repositories/Realizations/Base/RepositoryBase.cs
+++ b/Streetcode/Streetcode.DAL/Repositories/Realizations/Base/RepositoryBase.cs
@@ -155,6 +155,11 @@ namespace Streetcode.DAL.Repositories.Realizations.Base
 
                 var dataFromDb = ApplySpecificationForList(specification);
 
+                if (!dataFromDb.Any()) 
+                {
+                    return dataFromDb!;
+                }
+
                 await _redisCacheService.SetCachedDataAsync(specification.CacheKey, dataFromDb, specification.CacheMinutes);
 
                 return dataFromDb;
@@ -176,6 +181,11 @@ namespace Streetcode.DAL.Repositories.Realizations.Base
                 }
 
                 var dataFromDb = await ApplySpecificationForList(specification).FirstOrDefaultAsync();
+
+                if (dataFromDb == null)
+                {
+                    return dataFromDb!;
+                }
 
                 await _redisCacheService.SetCachedDataAsync(specification.CacheKey, dataFromDb, specification.CacheMinutes);
 

--- a/Streetcode/Streetcode.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/Streetcode/Streetcode.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -5,6 +5,7 @@ using Streetcode.DAL.Persistence;
 using Streetcode.DAL.Repositories.Interfaces.AdditionalContent;
 using Streetcode.DAL.Repositories.Interfaces.Analytics;
 using Streetcode.DAL.Repositories.Interfaces.Base;
+using Streetcode.DAL.Repositories.Interfaces.Comment;
 using Streetcode.DAL.Repositories.Interfaces.Media.Images;
 using Streetcode.DAL.Repositories.Interfaces.Newss;
 using Streetcode.DAL.Repositories.Interfaces.Partners;
@@ -18,6 +19,7 @@ using Streetcode.DAL.Repositories.Interfaces.Transactions;
 using Streetcode.DAL.Repositories.Interfaces.Users;
 using Streetcode.DAL.Repositories.Realizations.AdditionalContent;
 using Streetcode.DAL.Repositories.Realizations.Analytics;
+using Streetcode.DAL.Repositories.Realizations.Comment;
 using Streetcode.DAL.Repositories.Realizations.Media;
 using Streetcode.DAL.Repositories.Realizations.Media.Images;
 using Streetcode.DAL.Repositories.Realizations.Newss;
@@ -107,6 +109,7 @@ namespace Streetcode.DAL.Repositories.Realizations.Base
         private IStreetcodeToponymRepository _streetcodeToponymRepository;
 
         private IStreetcodeImageRepository _streetcodeImageRepository;
+        private ICommentRepository _commentRepository;
 
         public RepositoryWrapper(StreetcodeDbContext streetcodeDbContext, IRedisCacheService redisCacheService)
         {
@@ -449,6 +452,19 @@ namespace Streetcode.DAL.Repositories.Realizations.Base
                 }
 
                 return _relatedTermRepository;
+            }
+        }
+
+        public ICommentRepository CommentRepository
+        {
+            get
+            {
+                if (_commentRepository is null)
+                {
+                    _commentRepository = new CommentRepository(_streetcodeDbContext, redisCacheService);
+                }
+
+                return _commentRepository;
             }
         }
 

--- a/Streetcode/Streetcode.DAL/Repositories/Realizations/Comment/CommentRepository.cs
+++ b/Streetcode/Streetcode.DAL/Repositories/Realizations/Comment/CommentRepository.cs
@@ -1,0 +1,23 @@
+﻿using Streetcode.DAL.Caching.RedisCache;
+using Streetcode.DAL.Entities.Analytics;
+using Streetcode.DAL.Persistence;
+using Streetcode.DAL.Repositories.Interfaces.Analytics;
+using Streetcode.DAL.Repositories.Interfaces.Comment;
+using Streetcode.DAL.Repositories.Realizations.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommentEntity = Streetcode.DAL.Entities.Comment.Comment;
+
+namespace Streetcode.DAL.Repositories.Realizations.Comment
+{
+    public class CommentRepository : RepositoryBase<CommentEntity>, ICommentRepository
+    {
+        public CommentRepository(StreetcodeDbContext context, IRedisCacheService redisCacheService)
+            : base(context, redisCacheService)
+        {
+        }
+    }
+}

--- a/Streetcode/Streetcode.WebApi/Controllers/Comment/CommentController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Comment/CommentController.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Streetcode.BLL.DTO.Analytics;
+using Streetcode.BLL.MediatR.Analytics.Delete;
+using Streetcode.BLL.MediatR.Analytics;
+using UserService.BLL.Attributes;
+using UserService.DAL.Enums;
+using Streetcode.BLL.MediatR.Streetcode.RelatedTerm.GetAllByTermId;
+using Streetcode.BLL.MediatR.Comment.GetCommentsByStreetcodeId;
+
+namespace Streetcode.WebApi.Controllers.Comment
+{
+    public class CommentController : BaseApiController
+    {
+        // [AuthorizeRoles(UserRole.Admin, UserRole.User)]
+        [HttpGet("{streetcodeid:int}")]
+        public async Task<IActionResult> GetByStreetcodeId([FromRoute] int streetcodeid)
+        {
+            return HandleResult(await Mediator.Send(new GetCommentsByStreetcodeIdQuery(streetcodeid)));
+        }
+    }
+}

--- a/Streetcode/Streetcode.WebApi/Controllers/Comment/CommentController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Comment/CommentController.cs
@@ -11,7 +11,6 @@ namespace Streetcode.WebApi.Controllers.Comment
 {
     public class CommentController : BaseApiController
     {
-        // [AuthorizeRoles(UserRole.Admin, UserRole.User)]
         [HttpGet("{streetcodeid:int}")]
         public async Task<IActionResult> GetByStreetcodeId([FromRoute] int streetcodeid)
         {

--- a/Streetcode/Streetcode.WebApi/Extensions/SeedingLocalExtension.cs
+++ b/Streetcode/Streetcode.WebApi/Extensions/SeedingLocalExtension.cs
@@ -1432,6 +1432,39 @@ namespace Streetcode.WebApi.Extensions
 
                                     await dbContext.SaveChangesAsync();
                                 }
+
+                                if (!dbContext.Comments.Any())
+                                {
+                                    await dbContext.Comments.AddRangeAsync(
+                                        new DAL.Entities.Comment.Comment
+                                        {
+                                            UserName = "user",
+                                            UserFullName = "user",
+                                            CreatedDate = DateTime.Now,
+                                            Content = "Хочу бути горошком",
+                                            StreetcodeId = 1
+                                        },
+                                        new DAL.Entities.Comment.Comment
+                                        {
+                                            UserName = "admin",
+                                            UserFullName = "admin",
+                                            CreatedDate = DateTime.Now,
+                                            Content = "Я теж",
+                                            StreetcodeId = 1,
+                                            ParentId = 1,
+                                        },
+                                        new DAL.Entities.Comment.Comment
+                                        {
+                                            UserName = "user",
+                                            UserFullName = "user",
+                                            CreatedDate = DateTime.Now,
+                                            Content = "Хорош",
+                                            StreetcodeId = 1,
+                                            ParentId = 2,
+                                        });
+
+                                    await dbContext.SaveChangesAsync();
+                                }
                             }
                         }
                     }

--- a/Streetcode/Streetcode.XUnitTest/ControllerTests/CommentControllerTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/ControllerTests/CommentControllerTest.cs
@@ -1,0 +1,59 @@
+﻿using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Streetcode.BLL.DTO.Streetcode.TextContent;
+using Streetcode.WebApi.Controllers.Streetcode.TextContent;
+using Streetcode.WebApi.Controllers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Streetcode.BLL.MediatR.Comment.GetCommentsByStreetcodeId;
+using Streetcode.BLL.DTO.Comment;
+using Streetcode.BLL.MediatR.Streetcode.RelatedTerm.GetById;
+using Streetcode.WebApi.Controllers.Comment;
+
+namespace Streetcode.XUnitTest.ControllerTests
+{
+    public class CommentControllerTest
+    {
+        private readonly Mock<IMediator> _mediatorMock;
+        private readonly CommentController _controller;
+
+        public CommentControllerTest()
+        {
+            this._mediatorMock = new Mock<IMediator>();
+
+            this._controller = new CommentController();
+
+            var mediatorField = typeof(BaseApiController)
+                .GetField("_mediator", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            mediatorField.SetValue(this._controller, this._mediatorMock.Object);
+        }
+
+        [Fact]
+        public async Task GetAllCommentsByStreetcodeId_ReturnsAllComments()
+        {
+            // Arrange
+            var mockDtos = new List<GetCommentDto>
+            {
+                new GetCommentDto { Id = 1, StreetcodeId = 1, Content = "Test Comment 1" },
+                new GetCommentDto { Id = 2, StreetcodeId = 1, Content = "Test Comment 2" }
+            };
+
+            this._mediatorMock.Setup(m => m.Send(It.IsAny<GetCommentsByStreetcodeIdQuery>(), default))
+                              .ReturnsAsync(mockDtos);
+
+            // Act
+            var result = await this._controller.GetByStreetcodeId(1);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(mockDtos, okResult.Value);
+        }
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Comment/GetCommentsByStreetcodeIdHandlerTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Comment/GetCommentsByStreetcodeIdHandlerTest.cs
@@ -1,0 +1,126 @@
+﻿using AutoMapper;
+using FluentResults;
+using Moq;
+using Streetcode.BLL.DTO.Comment;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.MediatR.Comment.GetCommentsByStreetcodeId;
+using Streetcode.BLL.Specifications.Comment;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Streetcode.DAL.Specification;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using CommentEntity = Streetcode.DAL.Entities.Comment.Comment;
+
+namespace Streetcode.XUnitTest.MediatRTests.Comment
+{
+    public class GetCommentsByStreetcodeIdHandlerTest
+    {
+        private readonly Mock<IMapper> _mapperMock;
+        private readonly Mock<IRepositoryWrapper> _repositoryMock;
+        private readonly Mock<ILoggerService> _loggerMock;
+        private readonly GetCommentsByStreetcodeIdHandler _handler;
+
+        public GetCommentsByStreetcodeIdHandlerTest()
+        {
+            _mapperMock = new Mock<IMapper>();
+            _repositoryMock = new Mock<IRepositoryWrapper>();
+            _loggerMock = new Mock<ILoggerService>();
+
+            _handler = new GetCommentsByStreetcodeIdHandler(
+                _mapperMock.Object,
+                _repositoryMock.Object,
+                _loggerMock.Object
+            );
+        }
+
+        [Fact]
+        public async Task Handle_ReturnsOkResult_WhenCommentsExist()
+        {
+            // Arrange
+            var streetcodeId = 123;
+            var request = new GetCommentsByStreetcodeIdQuery(streetcodeId);
+
+            var mockComments = new List<CommentEntity>
+        {
+            new CommentEntity { Id = 1, StreetcodeId = streetcodeId, Content = "Test Comment 1" },
+            new CommentEntity { Id = 2, StreetcodeId = streetcodeId, Content = "Test Comment 2" }
+        };
+
+            var mockDtos = new List<GetCommentDto>
+        {
+            new GetCommentDto { Id = 1, StreetcodeId = streetcodeId, Content = "Test Comment 1" },
+            new GetCommentDto { Id = 2, StreetcodeId = streetcodeId, Content = "Test Comment 2" }
+        };
+
+            _repositoryMock
+                .Setup(repo => repo.CommentRepository.GetAllBySpecAsync(It.IsAny<CommentByStreetcodeIdSpecification>()))
+                .ReturnsAsync(mockComments);
+
+            _mapperMock
+                .Setup(mapper => mapper.Map<IEnumerable<GetCommentDto>>(mockComments))
+                .Returns(mockDtos);
+
+            // Act
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(result.Value);
+            Assert.Equal(2, result.Value.Count());
+        }
+
+        [Fact]
+        public async Task Handle_ReturnsErrorResult_WhenCommentsNotFound()
+        {
+            // Arrange
+            var streetcodeId = 123;
+            var request = new GetCommentsByStreetcodeIdQuery(streetcodeId);
+
+            _repositoryMock
+                .Setup(repo => repo.CommentRepository.GetAllBySpecAsync(It.IsAny<CommentByStreetcodeIdSpecification>()))
+                .ReturnsAsync((IEnumerable<CommentEntity>)null!);
+
+            // Act
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.False(result.IsSuccess);
+            Assert.Equal("Error with Message='Cannot find a comment by a streetcode id: 123'", result.Errors[0].ToString());
+            Assert.IsAssignableFrom<Result<IEnumerable<GetCommentDto>>>(result);
+        }
+
+        [Fact]
+        public async Task Handle_ReturnsErrorResult_WhenMappingFails()
+        {
+            // Arrange
+            var streetcodeId = 123;
+            var request = new GetCommentsByStreetcodeIdQuery(streetcodeId);
+
+            var mockComments = new List<CommentEntity>
+        {
+            new CommentEntity { Id = 1, StreetcodeId = streetcodeId, Content = "Test Comment 1" },
+            new CommentEntity { Id = 2, StreetcodeId = streetcodeId, Content = "Test Comment 2" }
+        };
+
+            _repositoryMock
+                .Setup(repo => repo.CommentRepository.GetAllBySpecAsync(It.IsAny<CommentByStreetcodeIdSpecification>()))
+                .ReturnsAsync(mockComments);
+
+            _mapperMock
+                .Setup(mapper => mapper.Map<IEnumerable<GetCommentDto>>(mockComments))
+                .Returns((IEnumerable<GetCommentDto>)null!);
+
+            // Act
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.False(result.IsSuccess);
+            Assert.Equal("Error with Message='Cannot find any DTOS for comments'", result.Errors[0].ToString());
+            Assert.IsAssignableFrom<Result<IEnumerable<GetCommentDto>>>(result);
+        }
+    }
+}


### PR DESCRIPTION
##Summary
Created:
- Comment entity
- CommentConfiguration for Comment entity
- CommentRepository and ICommentRepository
- CommentProfile for Mapper
- GetCommentDto
- CommentByStreetcodeIdSpecification with caching
- GetCommentsByStreetcodeIdHandler and Query
- CommentController
- CommentControllerTest
- GetCommentsByStreetcodeIdHandlerTest
- Created some migrations for Comment entity

Updated:
- StreetcodeContent entity: Added relationship with Comment entity
- StreetcodeDbContext: Added DbSet<> for Comment entity
- RepositoryWrapper: Added ICommentRepository field and getter
- ReppositoryBase: Added new checks for specification methods
- SeedingLocalExtension: Added seeding for Comment entity