### PR TITLE
fix/151: change deleting logic for RelatedTerm

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedTerm/Delete/DeleteRelatedTermCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedTerm/Delete/DeleteRelatedTermCommand.cs
@@ -4,5 +4,5 @@ using Streetcode.BLL.DTO.Streetcode.TextContent;
 
 namespace Streetcode.BLL.MediatR.Streetcode.RelatedTerm.Delete
 {
-    public record DeleteRelatedTermCommand(string word) : IRequest<Result<RelatedTermDTO>>;
+    public record DeleteRelatedTermCommand(string Word, int TermId) : IRequest<Result<Unit>>;
 }

--- a/Streetcode/Streetcode.BLL/Specifications/Streetcode/RelatedTerm/RelatedTermByWordAndTermIdSpecification.cs
+++ b/Streetcode/Streetcode.BLL/Specifications/Streetcode/RelatedTerm/RelatedTermByWordAndTermIdSpecification.cs
@@ -1,0 +1,18 @@
+﻿using Streetcode.DAL.Specification;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using RelatedTermEntity = Streetcode.DAL.Entities.Streetcode.TextContent.RelatedTerm;
+
+namespace Streetcode.BLL.Specifications.Streetcode.RelatedTerm
+{
+    public class RelatedTermByWordAndTermIdSpecification : BaseSpecification<RelatedTermEntity>
+    {
+        public RelatedTermByWordAndTermIdSpecification(string word, int termId)
+            : base(rt => rt.Word.ToLower().Equals(word.ToLower()) && rt.TermId == termId)
+        {
+        }
+    }
+}

--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/RelatedTermController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/RelatedTermController.cs
@@ -41,10 +41,10 @@ namespace Streetcode.WebApi.Controllers.Streetcode.TextContent
             return HandleResult(await Mediator.Send(new UpdateRelatedTermCommand(relatedTerm)));
         }
 
-        [HttpDelete("{word}")]
-        public async Task<IActionResult> Delete([FromRoute] string word)
+        [HttpDelete("{word}/{termId:int}")]
+        public async Task<IActionResult> Delete([FromRoute] string word, [FromRoute] int termId)
         {
-            return HandleResult(await Mediator.Send(new DeleteRelatedTermCommand(word)));
+            return HandleResult(await Mediator.Send(new DeleteRelatedTermCommand(word, termId)));
         }
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/ControllerTests/Streetcode/TextContent/RelatedTermControllerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/ControllerTests/Streetcode/TextContent/RelatedTermControllerTests.cs
@@ -137,16 +137,33 @@ namespace Streetcode.XUnitTest.ControllerTests.Streetcode.TextContent
         {
             // Arrange
             var wordToDelete = "TestTerm";
-            var relatedTerm = new RelatedTermDTO { Id = 1, Word = "TestTerm", TermId = 1 };
-            this._mediatorMock.Setup(m => m.Send(It.IsAny<DeleteRelatedTermCommand>(), default))
-                              .ReturnsAsync(relatedTerm);
+            int termIdToDelete = 1;
+            _mediatorMock.Setup(m => m.Send(It.IsAny<DeleteRelatedTermCommand>(), default))
+                .ReturnsAsync(Unit.Value);
 
             // Act
-            var result = await this._controller.Delete(wordToDelete);
+            var result = await _controller.Delete(wordToDelete, termIdToDelete);
 
             // Assert
-            var okResult = Assert.IsType<OkObjectResult>(result);
-            Assert.Equal(relatedTerm, okResult.Value);
+            result.Should().BeOfType<OkObjectResult>();
+        }
+
+        [Fact]
+        public async Task Delete_WhenHandlerFails_ReturnsBadRequest()
+        {
+            // Arrange
+            var word = "nonexistentWord";
+            var termId = 1;
+            var command = new DeleteRelatedTermCommand(word, termId);
+
+            _mediatorMock.Setup(m => m.Send(command, default))
+                .ReturnsAsync(Result.Fail("Failed to delete related term"));
+
+            // Act
+            var result = await _controller.Delete(word, termId);
+
+            // Assert
+            result.Should().BeOfType<BadRequestObjectResult>();
         }
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Streetcode/RelatedTermTests/Delete/DeleteRelatedTermHandlerTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Streetcode/RelatedTermTests/Delete/DeleteRelatedTermHandlerTest.cs
@@ -1,100 +1,77 @@
-﻿using AutoMapper;
-using FluentAssertions;
-using Streetcode.BLL.DTO.Streetcode.TextContent;
-using Streetcode.BLL.Interfaces.Logging;
-using Streetcode.BLL.Mapping.Streetcode.TextContent;
-using Streetcode.BLL.MediatR.Streetcode.RelatedTerm.Create;
+﻿using FluentAssertions;
+using FluentResults;
 using Streetcode.BLL.MediatR.Streetcode.RelatedTerm.Delete;
-using Streetcode.BLL.MediatR.Streetcode.RelatedTerm.GetById;
-using Streetcode.BLL.MediatR.Streetcode.RelatedTerm.Update;
 using Streetcode.DAL.Entities.Streetcode.TextContent;
 using Streetcode.DAL.Repositories.Interfaces.Base;
-using Microsoft.EntityFrameworkCore.Query;
 using Moq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 using Streetcode.DAL.Specification;
+using MediatR;
 
 namespace Streetcode.XUnitTest.MediatRTests.Streetcode.RelatedTermTests.Delete
 {
     public class DeleteRelatedTermHandlerTest
     {
-        private readonly IMapper _mapper;
         private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
-        private readonly Mock<ILoggerService> _mockLogger;
         private readonly DeleteRelatedTermHandler _handler;
 
         public DeleteRelatedTermHandlerTest()
         {
-            this._mockLogger = new Mock<ILoggerService>();
-            this._mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
-            var configuration = new MapperConfiguration(cfg =>
-            {
-                cfg.AddProfile(new RelatedTermProfile());
-            });
-            this._mapper = configuration.CreateMapper();
-            this._handler = new DeleteRelatedTermHandler(this._mockRepositoryWrapper.Object, this._mapper, this._mockLogger.Object);
+            _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+            _handler = new DeleteRelatedTermHandler(_mockRepositoryWrapper.Object);
         }
 
         [Fact]
-        public async Task WhenRelatedTermNotFound_thenReturnError()
+        public async Task ShouldThrowException_WhenRelatedTermNotFound()
         {
             // Arrange
-            var command = new DeleteRelatedTermCommand("nonexistentWord");
+            var command = new DeleteRelatedTermCommand("nonexistentWord", 1);
 
-            this._mockRepositoryWrapper.Setup(r => r.RelatedTermRepository.GetFirstOrDefaultBySpecAsync(
+            _mockRepositoryWrapper.Setup(r => r.RelatedTermRepository.GetFirstOrDefaultBySpecAsync(
                 It.IsAny<IBaseSpecification<RelatedTerm>>())).ReturnsAsync((RelatedTerm)null);
+
+            // Act
+            var exception = await Assert.ThrowsAsync<Exception>(() => _handler.Handle(command, CancellationToken.None));
+
+            // Assert
+            exception.Message.Should().Be("Cannot find any word");
+        }
+
+        [Fact]
+        public async Task ShouldThrowException_WhenDeleteFails()
+        {
+            // Arrange
+            var command = new DeleteRelatedTermCommand("existingWord", 1);
+            var relatedTerm = new RelatedTerm { Id = 1, Word = "existingWord", TermId = 1 };
+
+            _mockRepositoryWrapper.Setup(r => r.RelatedTermRepository.GetFirstOrDefaultBySpecAsync(
+                It.IsAny<IBaseSpecification<RelatedTerm>>())).ReturnsAsync(relatedTerm);
+            _mockRepositoryWrapper.Setup(r => r.SaveChangesAsync()).ReturnsAsync(0);
+
+            // Act
+            var exception = await Assert.ThrowsAsync<Exception>(() => _handler.Handle(command, CancellationToken.None));
+
+            // Assert
+            exception.Message.Should().Be("Failed to delete a word");
+        }
+
+        [Fact]
+        public async Task WhenDeleteSucceeds_ThenReturnDeletedRelatedTerm()
+        {
+            // Arrange
+            var command = new DeleteRelatedTermCommand("existingWord", 1);
+            var relatedTerm = new RelatedTerm { Id = 1, Word = "existingWord", TermId = 1 };
+
+            _mockRepositoryWrapper.Setup(r => r.RelatedTermRepository.GetFirstOrDefaultBySpecAsync(
+                It.IsAny<IBaseSpecification<RelatedTerm>>())).ReturnsAsync(relatedTerm);
+            _mockRepositoryWrapper.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
 
             // Act
             var result = await _handler.Handle(command, CancellationToken.None);
 
             // Assert
-            result.IsSuccess.Should().BeFalse();
-            result.Errors[0].Message.Should().Be("Cannot find a related term: nonexistentWord");
-        }
-
-        [Fact]
-        public async Task WhenDeleteFails_thenReturnError()
-        {
-            // Arrange
-            var command = new DeleteRelatedTermCommand("existingWord");
-            var relatedTerm = new RelatedTerm { Id = 1, Word = "existingWord", TermId = 1 };
-
-            this._mockRepositoryWrapper.Setup(r => r.RelatedTermRepository.GetFirstOrDefaultBySpecAsync(
-                It.IsAny<IBaseSpecification<RelatedTerm>>())).ReturnsAsync(relatedTerm);
-            this._mockRepositoryWrapper.Setup(r => r.SaveChangesAsync()).ReturnsAsync(0);
-
-            // Act
-            var result = await this._handler.Handle(command, CancellationToken.None);
-
-            // Assert
-            result.IsSuccess.Should().BeFalse();
-            result.Errors[0].Message.Should().Be("Failed to delete a related term");
-        }
-
-        [Fact]
-        public async Task WhenDeleteSucceeds_thenReturnDeletedRelatedTerm()
-        {
-            // Arrange
-            var command = new DeleteRelatedTermCommand("existingWord");
-            var relatedTerm = new RelatedTerm { Id = 1, Word = "existingWord", TermId = 1 };
-            var relatedTermDto = new RelatedTermDTO { Id = 1, Word = "existingWord", TermId = 1 };
-
-            this._mockRepositoryWrapper.Setup(r => r.RelatedTermRepository.GetFirstOrDefaultBySpecAsync(
-                It.IsAny<IBaseSpecification<RelatedTerm>>())).ReturnsAsync(relatedTerm);
-            this._mockRepositoryWrapper.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
-
-            // Act
-            var result = await this._handler.Handle(command, CancellationToken.None);
-
-            // Assert
             result.IsSuccess.Should().BeTrue();
-            result.Value.Should().BeEquivalentTo(relatedTermDto);
+            result.Value.Should().Be(Unit.Value);
         }
     }
 }

--- a/Streetcode/docker-compose.dcproj
+++ b/Streetcode/docker-compose.dcproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="cache.env" />
-    <None Include="mongodb.env" />
     <None Include="sqlserver.env" />
     <None Include="docker-compose.override.yml">
       <DependentUpon>docker-compose.yml</DependentUpon>


### PR DESCRIPTION
1. Change deleting logic for RelatedTerm to make it possible unlink RelatedTerm by word an TermId
2. Add specification for searching RelatedTerm by word and TermId
3. Change RelatedTerm controller
4. Change unit tests



dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
