### PR TITLE
tests/SSAD-237: Created unit test for MediatR/Transactions

### DIFF
--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Timeline/TimelineItem/Delete/DeleteTimelineItemTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Timeline/TimelineItem/Delete/DeleteTimelineItemTest.cs
@@ -1,4 +1,5 @@
-﻿using MediatR;
+﻿using FluentAssertions;
+using MediatR;
 using Microsoft.EntityFrameworkCore.Query;
 using Moq;
 using Streetcode.BLL.Interfaces.Logging;
@@ -74,7 +75,7 @@ namespace Streetcode.XUnitTest.MediatRTests.Timeline.TimelineItems.Delete
             var result = await _handler.Handle(command, default);
 
             // Arrange
-            Assert.True(result.IsSuccess);
+            result.IsSuccess.Should().BeTrue();
             Assert.Equal(Unit.Value, result.Value);
         }
 

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetAllTransactLinksHandlerTests/GetAllTransactLinksHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetAllTransactLinksHandlerTests/GetAllTransactLinksHandlerTests.cs
@@ -1,0 +1,89 @@
+﻿using AutoMapper;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore.Query;
+using Moq;
+using Streetcode.BLL.DTO.Transactions;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.Mapping.Transactions;
+using Streetcode.BLL.MediatR.Transactions.TransactionLink.GetAll;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using System.Linq.Expressions;
+using Xunit;
+using TransactLinkEntity = Streetcode.DAL.Entities.Transactions.TransactionLink;
+
+namespace Streetcode.XUnitTest.MediatRTests.Transactions.TransactionLink.GetAllTransactLinksHandlerTests
+{
+    public class GetAllTransactLinksHandlerTests
+    {
+        private readonly IMapper _mapper;
+        private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+        private readonly Mock<ILoggerService> _mockLogger;
+        private readonly GetAllTransactLinksHandler _handler;
+
+        public GetAllTransactLinksHandlerTests()
+        {
+            _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+            _mockLogger = new Mock<ILoggerService>();
+            var cfg = new MapperConfiguration(cfg => cfg.AddProfile(typeof(TransactionLinkProfile)));
+            _mapper = cfg.CreateMapper();
+            _handler = new GetAllTransactLinksHandler(_mockRepositoryWrapper.Object, _mapper, _mockLogger.Object);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnSuccessResultWithDTOs_WhenDataExists()
+        {
+            // Arrange
+            var transactLinks = GetTransactLinks();
+            ConfigureRepositoryToReturn(transactLinks);
+
+            // Act
+            var result = await _handler.Handle(new GetAllTransactLinksQuery(), CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().NotBeNullOrEmpty().And.HaveCount(transactLinks.Count);
+            _mockLogger.Verify(logger => logger.LogError(It.IsAny<object>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnFailResultAndLogError_WhenDataIsNull()
+        {
+            // Arrange
+            ConfigureRepositoryToReturn(null!);
+
+            // Act
+            var result = await _handler.Handle(new GetAllTransactLinksQuery(), CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsFailed.Should().BeTrue();
+            result.Errors.Should().ContainSingle(error => error.Message.Contains("transaction link"));
+
+            _mockLogger.Verify(logger => logger.LogError(It.IsAny<object>(), It.Is<string>(msg => msg.Contains("transaction link"))), Times.Once);
+        }
+
+        private void ConfigureRepositoryToReturn(List<TransactLinkEntity> transactLinks)
+        {
+            _mockRepositoryWrapper
+                .Setup(repo => repo.TransactLinksRepository.GetAllAsync(
+                    It.IsAny<Expression<Func<TransactLinkEntity, bool>>>(),
+                    It.IsAny<Func<IQueryable<TransactLinkEntity>, IIncludableQueryable<TransactLinkEntity, object>>>()))
+                .ReturnsAsync(transactLinks);
+        }
+
+        private List<TransactLinkEntity> GetTransactLinks() =>
+            new()
+            {
+                new TransactLinkEntity { Id = 1, Url = "URL", UrlTitle = "Title", StreetcodeId = 1 },
+                new TransactLinkEntity { Id = 2, Url = "URL2", UrlTitle = "Title2", StreetcodeId = 2 },
+            };
+
+        private List<TransactLinkDTO> GetTransactLinkDTOs() =>
+            new()
+            {
+                new TransactLinkDTO { Id = 1, Url = "URL", QrCodeUrl = "QrCodeUrl", StreetcodeId = 1 },
+                new TransactLinkDTO { Id = 2, Url = "URL2", QrCodeUrl = "QrCodeUrl2", StreetcodeId = 2 },
+            };
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetTransactLinkByIdHandlerTests/GetTransactLinkByIdHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetTransactLinkByIdHandlerTests/GetTransactLinkByIdHandlerTests.cs
@@ -1,0 +1,100 @@
+﻿using AutoMapper;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore.Query;
+using Moq;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Engineering;
+using Streetcode.BLL.DTO.Transactions;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.MediatR.Transactions.TransactionLink.GetById;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using System.Linq.Expressions;
+using Xunit;
+using TransactLinkEntity = Streetcode.DAL.Entities.Transactions.TransactionLink;
+namespace Streetcode.XUnitTest.MediatRTests.Transactions.TransactionLink.GetTransactLinkByIdHandlerTests
+{
+    public class GetTransactLinkByIdHandlerTests
+    {
+        private readonly IMapper _mapper;
+        private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+        private readonly Mock<ILoggerService> _mockLogger;
+        private readonly GetTransactLinkByIdHandler _handler;
+
+        public GetTransactLinkByIdHandlerTests()
+        {
+            _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+            _mockLogger = new Mock<ILoggerService>();
+
+            var mapperConfig = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<TransactLinkEntity, TransactLinkDTO>();
+            });
+            _mapper = mapperConfig.CreateMapper();
+
+            _handler = new GetTransactLinkByIdHandler(_mockRepositoryWrapper.Object, _mapper, _mockLogger.Object);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnSuccessResult_WhenEntityExists()
+        {
+            List<TransactLinkEntity> transactLinks = GetTransactLinks();
+            ConfigureRepositoryToReturn(transactLinks);
+            int transactionId = 1;
+            var query = new GetTransactLinkByIdQuery(transactionId);
+
+            // Act
+            var result = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().NotBeNull();
+            result.Value.Id.Should().Be(1);
+            result.Value.Url.Should().Be("URL");
+            result.Value.StreetcodeId.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnFailResult_WhenEntityDoesNotExist()
+        {
+            int transactionId = 1;
+            ConfigereRepositoryToReturnNull();
+            var query = new GetTransactLinkByIdQuery(transactionId);
+            var result = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsFailed.Should().BeTrue();
+            result.Errors.Should().ContainSingle();
+            _mockLogger.Verify(logger => logger.LogError(It.IsAny<object>(), It.IsAny<string>()), Times.Once);
+        }
+
+        private void ConfigureRepositoryToReturn(List<TransactLinkEntity> transactLinks)
+        {
+            this._mockRepositoryWrapper
+            .Setup(x => x.TransactLinksRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<TransactLinkEntity, bool>>>(),
+                It.IsAny<Func<IQueryable<TransactLinkEntity>, IIncludableQueryable<TransactLinkEntity, object>>>()))
+            .ReturnsAsync((Expression<Func<TransactLinkEntity, bool>> predicate,
+                           Func<IQueryable<TransactLinkEntity>, IIncludableQueryable<TransactLinkEntity, object>> include) =>
+            {
+                return transactLinks.AsQueryable().FirstOrDefault(predicate.Compile());
+            });
+        }
+
+        private void ConfigereRepositoryToReturnNull()
+        {
+            _mockRepositoryWrapper
+                .Setup(repo => repo.TransactLinksRepository.GetFirstOrDefaultAsync(
+                    It.IsAny<Expression<Func<TransactLinkEntity, bool>>>(),
+                    It.IsAny<Func<IQueryable<TransactLinkEntity>, IIncludableQueryable<TransactLinkEntity, object>>>()))
+                .ReturnsAsync((TransactLinkEntity?)null);
+        }
+
+        private List<TransactLinkEntity> GetTransactLinks() =>
+            new()
+            {
+           new TransactLinkEntity { Id = 1, Url = "URL", UrlTitle = "Title", StreetcodeId = 1 },
+           new TransactLinkEntity { Id = 2, Url = "URL2", UrlTitle = "Title2", StreetcodeId = 2 },
+            };
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetTransactLinkByStreetcodeIdHandler/GetTransactLinkByStreetcodeIdHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetTransactLinkByStreetcodeIdHandler/GetTransactLinkByStreetcodeIdHandlerTests.cs
@@ -1,0 +1,137 @@
+﻿using AutoMapper;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore.Query;
+using Moq;
+using Streetcode.BLL.DTO.Transactions;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.Mapping.Transactions;
+using Streetcode.BLL.MediatR.Transactions.TransactionLink.GetByStreetcodeId;
+using Streetcode.DAL.Entities.Streetcode;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using System.Linq.Expressions;
+using Xunit;
+using TransactLinkEntity = Streetcode.DAL.Entities.Transactions.TransactionLink;
+namespace Streetcode.XUnitTest.MediatRTests.Transactions.TransactionLink.GetTransactLinkByStreetcodeIdHandlerTests
+{
+    public class GetTransactLinkByStreetcodeIdHandlerTests
+    {
+        private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+        private readonly IMapper _mapper;
+        private readonly Mock<ILoggerService> _loggerMock;
+        private readonly GetTransactLinkByStreetcodeIdHandler _handler;
+
+        public GetTransactLinkByStreetcodeIdHandlerTests()
+        {
+            _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+            var cfg = new MapperConfiguration(cfg => cfg.AddProfile(typeof(TransactionLinkProfile)));
+            _mapper = cfg.CreateMapper();
+            _loggerMock = new Mock<ILoggerService>();
+            _handler = new GetTransactLinkByStreetcodeIdHandler(_repositoryWrapperMock.Object, _mapper, _loggerMock.Object);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnMappedTransactLink_WhenTransactLinkExists()
+        {
+            // Arrange
+            int streetcodeId = 1;
+            var request = new GetTransactLinkByStreetcodeIdQuery(streetcodeId);
+            var transactLinks = GetTransactLinks();
+
+            ConfigureTransactRepository(transactLinks);
+
+            // Act
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Url.Should().Be("URL");
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnError_WhenTransactLinkAndStreetcodeDoNotExist()
+        {
+            int streetcodeId = 155;
+            var transactLinks = GetTransactLinks();
+            var streetcodes = GetStreetcodes();
+            ConfigureStreetcodeRepository(streetcodes);
+            ConfigureTransactRepository(transactLinks);
+            SetupLogger();
+
+            // Arrange
+            var request = new GetTransactLinkByStreetcodeIdQuery(streetcodeId);
+
+            // Act
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            result.IsFailed.Should().BeTrue();
+            result.Errors.Should().ContainSingle();
+
+            _loggerMock.Verify(logger => logger.LogError(request, It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnNullResult_WhenTransactLinkIsNullButStreetcodeExists()
+        {
+            // Arrange
+            int streetcodeId = 1;
+            var request = new GetTransactLinkByStreetcodeIdQuery(streetcodeId);
+            var streetcode = new StreetcodeContent { Id = 1 };
+            var streetcodeList = GetStreetcodes();
+            ConfigureStreetcodeRepository(streetcodeList);
+            ConfigureTransactRepository(null!);
+
+            // Act
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().BeNull();
+        }
+
+        private void ConfigureTransactRepository(List<TransactLinkEntity>? transactLinks)
+        {
+            this._repositoryWrapperMock
+                .Setup(x => x.TransactLinksRepository.GetFirstOrDefaultAsync(
+                    It.IsAny<Expression<Func<TransactLinkEntity, bool>>>(),
+                    It.IsAny<Func<IQueryable<TransactLinkEntity>, IIncludableQueryable<TransactLinkEntity, object>>>()))
+                .ReturnsAsync((Expression<Func<TransactLinkEntity, bool>> predicate,
+                               Func<IQueryable<TransactLinkEntity>, IIncludableQueryable<TransactLinkEntity, object>> include) =>
+                {
+                    return transactLinks?.AsQueryable().FirstOrDefault(predicate.Compile());
+                });
+        }
+
+        private void ConfigureStreetcodeRepository(List<StreetcodeContent> streetcodes)
+        {
+            this._repositoryWrapperMock
+            .Setup(x => x.StreetcodeRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<StreetcodeContent, bool>>>(),
+                It.IsAny<Func<IQueryable<StreetcodeContent>, IIncludableQueryable<StreetcodeContent, object>>>()))
+            .ReturnsAsync((Expression<Func<StreetcodeContent, bool>> predicate,
+                Func<IQueryable<StreetcodeContent>, IIncludableQueryable<StreetcodeContent, object>> include) =>
+            {
+                return streetcodes.AsQueryable().FirstOrDefault(predicate.Compile());
+            });
+        }
+
+        private void SetupLogger()
+        {
+            _loggerMock.Setup(logger => logger.LogError(It.IsAny<object>(), It.IsAny<string>()));
+        }
+
+        private List<TransactLinkEntity> GetTransactLinks() =>
+             new()
+             {
+           new TransactLinkEntity { Id = 1, Url = "URL", UrlTitle = "Title", StreetcodeId = 1 },
+           new TransactLinkEntity { Id = 2, Url = "URL2", UrlTitle = "Title2", StreetcodeId = 2 },
+             };
+
+        private List<StreetcodeContent> GetStreetcodes() =>
+            new()
+            {
+            new StreetcodeContent { Id = 1 },
+            new StreetcodeContent { Id = 2 },
+            };
+    }
+}


### PR DESCRIPTION
Added new test classes: GetAllTransactLinksHandlerTests, GetTransactLinkByIdHandlerTests, and GetTransactLinkByStreetcodeIdHandlerTests.
These new tests verify various handler behaviors using FluentAssertions for assertions and Moq for mocking dependencies.