### PR TITLE
Fix some codesmells from SonarQube

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Instagram/GetAll/GetAllPostsHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Instagram/GetAll/GetAllPostsHandler.cs
@@ -20,6 +20,7 @@ namespace Streetcode.BLL.MediatR.Instagram.GetAll
         public async Task<Result<IEnumerable<InstagramPost>>> Handle(GetAllPostsQuery request, CancellationToken cancellationToken)
         {
             var result = await _instagramService.GetPostsAsync();
+            _logger.LogInformation("Obtained InstagramPosts from InstagramService.");
             return Result.Ok(result);
         }
     }

--- a/Streetcode/Streetcode.BLL/MediatR/Payment/CreateInvoiceHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Payment/CreateInvoiceHandler.cs
@@ -11,12 +11,10 @@ namespace Streetcode.BLL.MediatR.Payment
         private const int _hryvnyaCurrencyCode = 980;
         private const int _currencyMultiplier = 100;
         private readonly IPaymentService _paymentService;
-        private readonly ILoggerService _logger;
 
-        public CreateInvoiceHandler(IPaymentService paymentService, ILoggerService logger)
+        public CreateInvoiceHandler(IPaymentService paymentService)
         {
             _paymentService = paymentService;
-            _logger = logger;
         }
 
         public async Task<Result<InvoiceInfo>> Handle(CreateInvoiceCommand request, CancellationToken cancellationToken)

--- a/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/DeleteCategoryContent/DeleteCategoryContentHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/DeleteCategoryContent/DeleteCategoryContentHandler.cs
@@ -10,13 +10,11 @@ namespace Streetcode.BLL.MediatR.Sources.SourceLinkCategory.DeleteCategoryConten
 	public class DeleteCategoryContentHandler : IRequestHandler<DeleteCategoryContentCommand, Result<Unit>>
 	{
 		private readonly IRepositoryWrapper _repositoryWrapper;
-		private readonly IMapper _mapper;
 		private readonly ILoggerService _logger;
 
-		public DeleteCategoryContentHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper, ILoggerService logger)
+		public DeleteCategoryContentHandler(IRepositoryWrapper repositoryWrapper, ILoggerService logger)
 		{
 			_repositoryWrapper = repositoryWrapper;
-			_mapper = mapper;
 			_logger = logger;
 		}
 

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedFigure/Сreate/CreateRelatedFigureHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedFigure/Сreate/CreateRelatedFigureHandler.cs
@@ -10,14 +10,12 @@ namespace Streetcode.BLL.MediatR.Streetcode.RelatedFigure.Create
 {
     public class CreateRelatedFigureHandler : IRequestHandler<CreateRelatedFigureCommand, Result<Unit>>
     {
-        private readonly IMapper _mapper;
         private readonly IRepositoryWrapper _repositoryWrapper;
         private readonly ILoggerService _logger;
 
-        public CreateRelatedFigureHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper, ILoggerService logger)
+        public CreateRelatedFigureHandler(IRepositoryWrapper repositoryWrapper, ILoggerService logger)
         {
             _repositoryWrapper = repositoryWrapper;
-            _mapper = mapper;
             _logger = logger;
         }
 

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/GetAll/GetAllStreetcodesHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/GetAll/GetAllStreetcodesHandler.cs
@@ -13,13 +13,11 @@ namespace Streetcode.BLL.MediatR.Streetcode.Streetcode.GetAll
     {
         private readonly IMapper _mapper;
         private readonly IRepositoryWrapper _repositoryWrapper;
-        private readonly ILoggerService _logger;
 
-        public GetAllStreetcodesHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper, ILoggerService logger)
+        public GetAllStreetcodesHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper)
         {
             _repositoryWrapper = repositoryWrapper;
             _mapper = mapper;
-            _logger = logger;
         }
 
         public async Task<Result<GetAllStreetcodesResponseDTO>> Handle(GetAllStreetcodesQuery query, CancellationToken cancellationToken)

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/GetByFilter/GetStreetcodeByFilterHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/GetByFilter/GetStreetcodeByFilterHandler.cs
@@ -11,12 +11,10 @@ namespace Streetcode.BLL.MediatR.Streetcode.Streetcode.GetByFilter
     public class GetStreetcodeByFilterHandler : IRequestHandler<GetStreetcodeByFilterQuery, Result<List<StreetcodeFilterResultDTO>>>
     {
         private readonly IRepositoryWrapper _repositoryWrapper;
-        private readonly ILoggerService _logger;
 
-        public GetStreetcodeByFilterHandler(IRepositoryWrapper repositoryWrapper, ILoggerService logger)
+        public GetStreetcodeByFilterHandler(IRepositoryWrapper repositoryWrapper)
         {
             _repositoryWrapper = repositoryWrapper;
-            _logger = logger;
         }
 
         public async Task<Result<List<StreetcodeFilterResultDTO>>> Handle(GetStreetcodeByFilterQuery request, CancellationToken cancellationToken)

--- a/Streetcode/Streetcode.BLL/MediatR/Toponyms/GetAll/GetAllToponymsHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Toponyms/GetAll/GetAllToponymsHandler.cs
@@ -14,13 +14,11 @@ namespace Streetcode.BLL.MediatR.Toponyms.GetAll
     {
         private readonly IMapper _mapper;
         private readonly IRepositoryWrapper _repositoryWrapper;
-        private readonly ILoggerService _logger;
 
-        public GetAllToponymsHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper, ILoggerService logger)
+        public GetAllToponymsHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper)
         {
             _repositoryWrapper = repositoryWrapper;
             _mapper = mapper;
-            _logger = logger;
         }
 
         public async Task<Result<GetAllToponymsResponseDTO>> Handle(GetAllToponymsQuery query, CancellationToken cancellationToken)

--- a/Streetcode/Streetcode.WebApi/Utils/WebParsingUtils.cs
+++ b/Streetcode/Streetcode.WebApi/Utils/WebParsingUtils.cs
@@ -28,13 +28,11 @@ namespace Streetcode.WebApi.Utils
 
 		private readonly IRepositoryWrapper _repository;
 		private readonly StreetcodeDbContext _streetcodeContext;
-		private readonly IRedisCacheService _redisCacheService;
 
 		public WebParsingUtils(StreetcodeDbContext streetcodeContext, IRedisCacheService redisCacheService)
         {
             _repository = new RepositoryWrapper(streetcodeContext, redisCacheService);
             _streetcodeContext = streetcodeContext;
-            _redisCacheService = redisCacheService;
         }
 
 		public static async Task DownloadAndExtractAsync(

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Source/DeleteCategoryContent/DeleteCategoryContentHandlerTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Source/DeleteCategoryContent/DeleteCategoryContentHandlerTest.cs
@@ -19,16 +19,14 @@ namespace Streetcode.XUnitTest.MediatRTests.Source.DeleteCategoryContent
 	public class DeleteCategoryContentHandlerTest
 	{
 		private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
-		private readonly Mock<IMapper> _mockMapper;
 		private readonly Mock<ILoggerService> _mockLogger;
 		private readonly DeleteCategoryContentHandler _handler;
 
 		public DeleteCategoryContentHandlerTest()
 		{
 			_mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
-			_mockMapper = new Mock<IMapper>();
 			_mockLogger = new Mock<ILoggerService>();
-			_handler = new DeleteCategoryContentHandler(_mockRepositoryWrapper.Object, _mockMapper.Object, _mockLogger.Object);
+			_handler = new DeleteCategoryContentHandler(_mockRepositoryWrapper.Object, _mockLogger.Object);
 		}
 
 		[Fact]

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Toponyms/GetAll/GetAllToponymsHandlerTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Toponyms/GetAll/GetAllToponymsHandlerTest.cs
@@ -20,7 +20,6 @@ namespace Streetcode.XUnitTest.MediatRTests.Toponyms.GetAll
     {
         private readonly IMapper _mapper;
         private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
-        private readonly Mock<ILoggerService> _mockLogger;
         private readonly GetAllToponymsHandler _handler;
 
         /// <summary>
@@ -29,7 +28,6 @@ namespace Streetcode.XUnitTest.MediatRTests.Toponyms.GetAll
         /// </summary>
         public GetAllToponymsHandlerTest()
         {
-            _mockLogger = new Mock<ILoggerService>();
             _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
 
             var mapperConfiguration = new MapperConfiguration(cfg =>
@@ -37,7 +35,7 @@ namespace Streetcode.XUnitTest.MediatRTests.Toponyms.GetAll
                 cfg.AddProfile(typeof(ToponymProfile));
             });
             _mapper = mapperConfiguration.CreateMapper();
-            _handler = new GetAllToponymsHandler(_mockRepositoryWrapper.Object, _mapper, _mockLogger.Object);
+            _handler = new GetAllToponymsHandler(_mockRepositoryWrapper.Object, _mapper);
         }
 
         /// <summary>

--- a/Streetcode/UserService.BLL/UserService.BLL.csproj
+++ b/Streetcode/UserService.BLL/UserService.BLL.csproj
@@ -6,8 +6,6 @@
     <AssemblyTitle>UserService.BLL</AssemblyTitle>
     <Product>UserService.BLL</Product>
     <Copyright>Copyright ©  2024</Copyright>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />

--- a/Streetcode/UserService.DAL/UserService.DAL.csproj
+++ b/Streetcode/UserService.DAL/UserService.DAL.csproj
@@ -6,8 +6,6 @@
     <AssemblyTitle>UserService.DAL</AssemblyTitle>
     <Product>UserService.DAL</Product>
     <Copyright>Copyright ©  2024</Copyright>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AspNetCore.Identity.Mongo" Version="9.1.1" />


### PR DESCRIPTION
##Summary
Updated:
- GetAllPostsHandler: Added logging
- CreateInvoiceHandler: Removed logger related
- DeleteCategoryContentHandler:Removed mapper related
- CreateRelatedFigureHandler: Removed mapper related
- GetAllStreetcodesHandler: removed logger related
- GetStreetcodeByFilterHandler: removed logger related
- GetAllToponymsHandler: removed logger related
- WebParsingUtils: removed Private field redisCacheService
- UserService.BLL.csproj and UserService.DAL.csproj: removed assemblyVersion