### PR TITLE
maintainability/247/make-method-async-due-to-await

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/GetAll/GetAllStreetcodesHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/GetAll/GetAllStreetcodesHandler.cs
@@ -24,8 +24,9 @@ namespace Streetcode.BLL.MediatR.Streetcode.Streetcode.GetAll
         {
             var filterRequest = query.request;
 
-            var streetcodes = _repositoryWrapper.StreetcodeRepository
-                .FindAll();
+            var streetcodes = await _repositoryWrapper.StreetcodeRepository.GetAllAsync()
+                as IQueryable<StreetcodeContent>
+                ?? Enumerable.Empty<StreetcodeContent>().AsQueryable();
 
             if (filterRequest.Title is not null)
             {


### PR DESCRIPTION
Change logic of filling streetcodes from repository, cast it to IQueryable to not break logic of pass it to methods as ref parameter
