### PR TITLE
feat/277: Add feature to handle creation of comment replies

### DIFF
--- a/Streetcode/Streetcode.BLL/DTO/Comment/CreateReplyDto.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Comment/CreateReplyDto.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Streetcode.BLL.DTO.Comment
+{
+    public class CreateReplyDto
+    {
+        public string UserName { get; set; } = string.Empty;
+        public string UserFullName { get; set; } = string.Empty;
+        public DateTime CreatedDate { get; set; }
+        public DateTime? DateModified { get; set; }
+        public string Content { get; set; } = string.Empty;
+        public int StreetcodeId { get; set; }
+        public int ParentId { get; set; }
+    }
+}

--- a/Streetcode/Streetcode.BLL/Mapping/Comment/CommentProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Comment/CommentProfile.cs
@@ -18,7 +18,7 @@ namespace Streetcode.BLL.Mapping.Comment
             CreateMap<UpdateCommentDto, CommentEntity>();
 
             CreateMap<CommentEntity, GetCommentsToReviewDto>();
-
+            CreateMap<CreateReplyDto, CommentEntity>();
         }
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Comment/CreateReply/CreateReplyCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Comment/CreateReply/CreateReplyCommand.cs
@@ -1,0 +1,10 @@
+﻿using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Comment;
+
+namespace Streetcode.BLL.MediatR.Comment.CreateReply
+{
+    public record CreateReplyCommand(CreateReplyDto createReplyDto) : IRequest<Result<CreateReplyDto>>
+    {
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Comment/CreateReply/CreateReplyHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Comment/CreateReply/CreateReplyHandler.cs
@@ -1,0 +1,61 @@
+﻿using AutoMapper;
+using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Comment;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.Resources;
+using Streetcode.BLL.Specifications.Comment;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using CommentEntity = Streetcode.DAL.Entities.Comment.Comment;
+
+namespace Streetcode.BLL.MediatR.Comment.CreateReply
+{
+    public class CreateReplyHandler : IRequestHandler<CreateReplyCommand, Result<CreateReplyDto>>
+    {
+        private readonly IMapper _mapper;
+        private readonly IRepositoryWrapper _repositoryWrapper;
+        private readonly ILoggerService _logger;
+
+        public CreateReplyHandler(IMapper mapper, IRepositoryWrapper repositoryWrapper, ILoggerService logger)
+        {
+            _mapper = mapper;
+            _repositoryWrapper = repositoryWrapper;
+            _logger = logger;
+        }
+
+        public async Task<Result<CreateReplyDto>> Handle(CreateReplyCommand request, CancellationToken cancellationToken)
+        {
+            var existingParent = await _repositoryWrapper.CommentRepository
+                    .GetFirstOrDefaultBySpecAsync(new CommentByParentIdSpecification(request.createReplyDto.ParentId));
+
+            if (existingParent is null)
+            {
+                var errorMsg = ErrorManager.GetCustomErrorText("CantFindError", "comment", request.createReplyDto.ParentId);
+                _logger.LogError(request, errorMsg);
+                return Result.Fail(errorMsg);
+            }
+
+            var newReply = _mapper.Map<CommentEntity>(request.createReplyDto);
+
+            if (newReply is null)
+            {
+                var errMsg = ErrorManager.GetCustomErrorText("ConvertationError", "create reply dto", "CommentEntity");
+                _logger.LogError(request, errMsg);
+                return Result.Fail(errMsg);
+            }
+
+            var result = await _repositoryWrapper.CommentRepository.CreateAsync(newReply);
+
+            var resultIsSucceed = await _repositoryWrapper.SaveChangesAsync() > 0;
+
+            if (!resultIsSucceed)
+            {
+                var errMsg = ErrorManager.GetCustomErrorText("FailCreateError", "reply", "");
+                _logger.LogError(request, errMsg);
+                return Result.Fail(errMsg);
+            }
+
+            return Result.Ok(_mapper.Map<CreateReplyDto>(result));
+        }
+    }
+}

--- a/Streetcode/Streetcode.BLL/Specifications/Comment/CommentByParentIdSpecification.cs
+++ b/Streetcode/Streetcode.BLL/Specifications/Comment/CommentByParentIdSpecification.cs
@@ -1,0 +1,13 @@
+﻿using Streetcode.DAL.Specification;
+using CommentEntity = Streetcode.DAL.Entities.Comment.Comment;
+
+namespace Streetcode.BLL.Specifications.Comment
+{
+    public class CommentByParentIdSpecification : BaseSpecification<CommentEntity>
+    {
+        public CommentByParentIdSpecification(int parentId)
+            : base(c => c.Id == parentId)
+        {
+        }
+    }
+}

--- a/Streetcode/Streetcode.BLL/Validation/Validators/CommandsAndQuerysValidators/CreateReplyCommandValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validation/Validators/CommandsAndQuerysValidators/CreateReplyCommandValidator.cs
@@ -1,0 +1,17 @@
+﻿using FluentValidation;
+using Streetcode.BLL.MediatR.Comment.CreateReply;
+using Streetcode.BLL.Validation.Validators.DTOValidators.Comment;
+
+
+namespace Streetcode.BLL.Validation.Validators.CommandsAndQuerysValidators
+{
+    public class CreateReplyCommandValidator : AbstractValidator<CreateReplyCommand>
+    {
+        public CreateReplyCommandValidator()
+        {
+            RuleFor(x => x.createReplyDto)
+                .NotNull().WithMessage("CreateReplyDto object is required")
+                .SetValidator(new CreateReplyDtoValidator());
+        }
+    }
+}

--- a/Streetcode/Streetcode.BLL/Validation/Validators/DTOValidators/Comment/CreateReplyDtoValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validation/Validators/DTOValidators/Comment/CreateReplyDtoValidator.cs
@@ -1,0 +1,39 @@
+﻿using FluentValidation;
+using Streetcode.BLL.DTO.Comment;
+
+namespace Streetcode.BLL.Validation.Validators.DTOValidators.Comment
+{
+    public class CreateReplyDtoValidator : AbstractValidator<CreateReplyDto>
+    {
+        public CreateReplyDtoValidator()
+        {
+            RuleFor(x => x.UserName)
+                .NotEmpty().WithMessage("UserName is required.")
+                .MaximumLength(50).WithMessage("UserName must not exceed 50 characters.");
+
+            RuleFor(x => x.UserFullName)
+                .NotEmpty().WithMessage("UserFullName is required.")
+                .MaximumLength(100).WithMessage("UserFullName must not exceed 100 characters.");
+
+            RuleFor(x => x.CreatedDate)
+                .NotEmpty().WithMessage("CreatedDate is required.")
+                .LessThanOrEqualTo(DateTime.Now).WithMessage("CreatedDate cannot be in the future.");
+
+            RuleFor(x => x.DateModified)
+                .GreaterThanOrEqualTo(x => x.CreatedDate).WithMessage("DateModified cannot be earlier than CreatedDate.")
+                .When(x => x.DateModified.HasValue); // Only validate if DateModified is not null
+
+            RuleFor(x => x.Content)
+                .NotEmpty().WithMessage("Content is required.")
+                .MaximumLength(500).WithMessage("Content must not exceed 500 characters.");
+
+            RuleFor(x => x.StreetcodeId)
+                .NotEmpty().WithMessage("Reply must have streetcode Id")
+                .GreaterThan(0).WithMessage("StreetcodeId must be greater than 0.");
+
+            RuleFor(x => x.ParentId)
+                .NotEmpty().WithMessage("Reply must have ParentId")
+                .GreaterThan(0).WithMessage("ParentId must be greater than 0.");
+        }
+    }
+}

--- a/Streetcode/Streetcode.WebApi/Controllers/Comment/CommentController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Comment/CommentController.cs
@@ -13,6 +13,8 @@ using Streetcode.BLL.MediatR.Comment.UpdateComment;
 using Streetcode.BLL.MediatR.Comment.GetCommentByIdWithReplies;
 using Streetcode.BLL.MediatR.Comment.CreateComment;
 using Streetcode.BLL.MediatR.Comment.UserDeleteComment;
+using Microsoft.AspNetCore.Authorization;
+using Streetcode.BLL.MediatR.Comment.CreateReply;
 
 namespace Streetcode.WebApi.Controllers.Comment
 {
@@ -60,6 +62,13 @@ namespace Streetcode.WebApi.Controllers.Comment
         public async Task<IActionResult> UserDeleteComment([FromBody] UserDeleteCommentDto userDeleteCommentDto)
         {
             return HandleResult(await Mediator.Send(new UserDeleteCommentCommand(userDeleteCommentDto)));
+        }
+
+        [Authorize]
+        [HttpPost]
+        public async Task<ActionResult<CreateReplyDto>> CreateReply([FromBody] CreateReplyDto createReplyDto)
+        {
+            return HandleResult(await Mediator.Send(new CreateReplyCommand(createReplyDto)));
         }
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Comment/CreateReplyHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Comment/CreateReplyHandlerTests.cs
@@ -1,0 +1,130 @@
+﻿using AutoMapper;
+using Moq;
+using Streetcode.BLL.DTO.Comment;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.MediatR.Comment.CreateReply;
+using Streetcode.BLL.Specifications.Comment;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Xunit;
+using CommentEntity = Streetcode.DAL.Entities.Comment.Comment;
+
+namespace Streetcode.XUnitTest.MediatRTests.Comment
+{
+    public class CreateReplyHandlerTests
+    {
+        private readonly Mock<IMapper> _mapperMock;
+        private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+        private readonly Mock<ILoggerService> _loggerMock;
+        private readonly CreateReplyHandler _handler;
+
+        public CreateReplyHandlerTests()
+        {
+            _mapperMock = new Mock<IMapper>();
+            _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+            _loggerMock = new Mock<ILoggerService>();
+            _handler = new CreateReplyHandler(_mapperMock.Object, _repositoryWrapperMock.Object, _loggerMock.Object);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnError_WhenParentCommentNotFound()
+        {
+            // Arrange
+            var command = new CreateReplyCommand(new CreateReplyDto { ParentId = 1 });
+            _repositoryWrapperMock
+                .Setup(r => r.CommentRepository.GetFirstOrDefaultBySpecAsync(It.IsAny<CommentByParentIdSpecification>()))
+                .ReturnsAsync((CommentEntity)null!);
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsFailed);
+
+            // Verify that logger was called with the specific error message
+            _loggerMock.Verify(l => l.LogError(It.IsAny<CreateReplyCommand>(), It.Is<string>(msg => msg.Contains("Cannot find any comment"))), Times.Once);
+
+            // Verify that logger was not called for other issues in this scenario
+            _loggerMock.Verify(l => l.LogError(It.IsAny<CreateReplyCommand>(), It.Is<string>(msg => msg.Contains("Cannot convert create reply dto to CommentEntity"))), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnError_WhenMappingFails()
+        {
+            // Arrange
+            var command = new CreateReplyCommand(new CreateReplyDto { ParentId = 1 });
+            _repositoryWrapperMock
+                .Setup(r => r.CommentRepository.GetFirstOrDefaultBySpecAsync(It.IsAny<CommentByParentIdSpecification>()))
+                .ReturnsAsync(new CommentEntity());
+            _mapperMock
+                .Setup(m => m.Map<CommentEntity>(It.IsAny<CreateReplyDto>()))
+                .Returns((CommentEntity)null!);
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsFailed);
+            _loggerMock.Verify(l => l.LogError(It.IsAny<CreateReplyCommand>(), It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnError_WhenSaveChangesFails()
+        {
+            // Arrange
+            var command = new CreateReplyCommand(new CreateReplyDto { ParentId = 1 });
+            var replyEntity = new CommentEntity();
+
+            _repositoryWrapperMock
+                .Setup(r => r.CommentRepository.GetFirstOrDefaultBySpecAsync(It.IsAny<CommentByParentIdSpecification>()))
+                .ReturnsAsync(new CommentEntity());
+            _mapperMock
+                .Setup(m => m.Map<CommentEntity>(It.IsAny<CreateReplyDto>()))
+                .Returns(replyEntity);
+            _repositoryWrapperMock
+                .Setup(r => r.CommentRepository.CreateAsync(It.IsAny<CommentEntity>()))
+                .ReturnsAsync(replyEntity);
+            _repositoryWrapperMock
+                .Setup(r => r.SaveChangesAsync())
+                .ReturnsAsync(0);
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsFailed);
+            _loggerMock.Verify(l => l.LogError(It.IsAny<CreateReplyCommand>(), It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnSuccess_WhenReplyIsCreatedSuccessfully()
+        {
+            // Arrange
+            var command = new CreateReplyCommand(new CreateReplyDto { ParentId = 1 });
+            var replyEntity = new CommentEntity();
+            var replyDto = new CreateReplyDto();
+
+            _repositoryWrapperMock
+                .Setup(r => r.CommentRepository.GetFirstOrDefaultBySpecAsync(It.IsAny<CommentByParentIdSpecification>()))
+                .ReturnsAsync(new CommentEntity());
+            _mapperMock
+                .Setup(m => m.Map<CommentEntity>(It.IsAny<CreateReplyDto>()))
+                .Returns(replyEntity);
+            _repositoryWrapperMock
+                .Setup(r => r.CommentRepository.CreateAsync(It.IsAny<CommentEntity>()))
+                .ReturnsAsync(replyEntity);
+            _repositoryWrapperMock
+                .Setup(r => r.SaveChangesAsync())
+                .ReturnsAsync(1);
+            _mapperMock
+                .Setup(m => m.Map<CreateReplyDto>(It.IsAny<CommentEntity>()))
+                .Returns(replyDto);
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal(replyDto, result.Value);
+        }
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/ValidatorTests/CreateReplyCommandValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/ValidatorTests/CreateReplyCommandValidatorTests.cs
@@ -1,0 +1,47 @@
+﻿using Streetcode.BLL.DTO.Comment;
+using Streetcode.BLL.MediatR.Comment.CreateReply;
+using Streetcode.BLL.Validation.Validators.CommandsAndQuerysValidators;
+using Xunit;
+using FluentValidation.TestHelper;
+
+namespace Streetcode.XUnitTest.ValidatorTests
+{
+    public class CreateReplyCommandValidatorTests
+    {
+        private readonly CreateReplyCommandValidator _validator;
+
+        public CreateReplyCommandValidatorTests()
+        {
+            _validator = new CreateReplyCommandValidator();
+        }
+
+        [Fact]
+        public void Should_HaveError_When_CreateReplyDto_IsNull()
+        {
+            // Arrange
+            var command = new CreateReplyCommand(null!);
+
+            // Act
+            var result = _validator.TestValidate(command);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.createReplyDto)
+                .WithErrorMessage("CreateReplyDto object is required");
+        }
+
+        [Fact]
+        public void Should_NotHaveError_When_CreateReplyDto_IsValid()
+        {
+            // Arrange
+            var createReplyDto = new CreateReplyDto();
+
+            var command = new CreateReplyCommand(createReplyDto);
+
+            // Act
+            var result = _validator.TestValidate(command);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.createReplyDto);
+        }
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/ValidatorTests/CreateReplyDtoValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/ValidatorTests/CreateReplyDtoValidatorTests.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using FluentValidation.TestHelper;
+using Streetcode.BLL.DTO.Comment;
+using Streetcode.BLL.Validation.Validators.DTOValidators.Comment;
+using Xunit;
+
+namespace Streetcode.Tests.Validation.Validators
+{
+    public class CreateReplyDtoValidatorTests
+    {
+        private readonly CreateReplyDtoValidator _validator;
+
+        public CreateReplyDtoValidatorTests()
+        {
+            _validator = new CreateReplyDtoValidator();
+        }
+
+        [Fact]
+        public void Should_HaveError_When_UserNameIsEmpty()
+        {
+            // Arrange
+            var model = new CreateReplyDto { UserName = "" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.UserName)
+                  .WithErrorMessage("UserName is required.");
+        }
+
+        [Fact]
+        public void Should_HaveError_When_UserNameExceedsMaxLength()
+        {
+            // Arrange
+            var model = new CreateReplyDto { UserName = new string('a', 51) };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.UserName)
+                  .WithErrorMessage("UserName must not exceed 50 characters.");
+        }
+
+        [Fact]
+        public void Should_HaveError_When_UserFullNameIsEmpty()
+        {
+            // Arrange
+            var model = new CreateReplyDto { UserFullName = "" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.UserFullName)
+                  .WithErrorMessage("UserFullName is required.");
+        }
+
+        [Fact]
+        public void Should_HaveError_When_UserFullNameExceedsMaxLength()
+        {
+            // Arrange
+            var model = new CreateReplyDto { UserFullName = new string('a', 101) };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.UserFullName)
+                  .WithErrorMessage("UserFullName must not exceed 100 characters.");
+        }
+
+        [Fact]
+        public void Should_HaveError_When_CreatedDateIsInFuture()
+        {
+            // Arrange
+            var model = new CreateReplyDto { CreatedDate = DateTime.Now.AddMinutes(1) };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.CreatedDate)
+                  .WithErrorMessage("CreatedDate cannot be in the future.");
+        }
+
+        [Fact]
+        public void Should_HaveError_When_DateModifiedIsEarlierThanCreatedDate()
+        {
+            // Arrange
+            var model = new CreateReplyDto { CreatedDate = DateTime.Now, DateModified = DateTime.Now.AddMinutes(-1) };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.DateModified)
+                  .WithErrorMessage("DateModified cannot be earlier than CreatedDate.");
+        }
+
+        [Fact]
+        public void Should_HaveError_When_ContentIsEmpty()
+        {
+            // Arrange
+            var model = new CreateReplyDto { Content = "" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Content)
+                  .WithErrorMessage("Content is required.");
+        }
+
+        [Fact]
+        public void Should_HaveError_When_ContentExceedsMaxLength()
+        {
+            // Arrange
+            var model = new CreateReplyDto { Content = new string('a', 501) };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Content)
+                  .WithErrorMessage("Content must not exceed 500 characters.");
+        }
+
+        [Fact]
+        public void Should_HaveError_When_StreetcodeIdIsZero()
+        {
+            // Arrange
+            var model = new CreateReplyDto { StreetcodeId = 0 };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.StreetcodeId)
+                  .WithErrorMessage("StreetcodeId must be greater than 0.");
+        }
+
+        [Fact]
+        public void Should_HaveError_When_ParentIdIsZero()
+        {
+            // Arrange
+            var model = new CreateReplyDto { ParentId = 0 };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.ParentId)
+                  .WithErrorMessage("ParentId must be greater than 0.");
+        }
+
+        [Fact]
+        public void Should_NotHaveAnyErrors_When_ModelIsValid()
+        {
+            var now = DateTime.UtcNow.AddSeconds(-1);
+
+            // Arrange
+            var model = new CreateReplyDto
+            {
+                UserName = "ValidUser",
+                UserFullName = "Valid Full Name",
+                CreatedDate = now,
+                Content = "Valid content",
+                StreetcodeId = 1,
+                ParentId = 1
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+    }
+}


### PR DESCRIPTION
- Added mapping in `CommentProfile.cs` for `CreateReplyDto` to `CommentEntity`.
- Updated `CommentController.cs` with new `CreateReply` endpoint, including necessary `using` statements.
- Created `CreateReplyDto`, `CreateReplyCommand`, and `CreateReplyHandler` for handling reply creation.
- Added `CommentByParentIdSpecification` for fetching comments by parent ID.
- Implemented validators for `CreateReplyCommand` and `CreateReplyDto`.
- Added unit tests for `CreateReplyHandler`, `CreateReplyCommandValidator`, and `CreateReplyDtoValidator`.

dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
