### PR TITLE
fix/314: Update holidayNodes check to use Any() for emptiness

### DIFF
--- a/Streetcode/Streetcode.WebApi/Controllers/HolidayDate/Parsers/HolidaySource1Parser.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/HolidayDate/Parsers/HolidaySource1Parser.cs
@@ -30,7 +30,7 @@ namespace Streetcode.WebApi.Controllers.HolidayDate.Parsers
                 .Any(child => child.GetAttributeValue("class", "")
                 .Contains("dayto-v-spysku-novyy") && child.GetAttributeValue("id", "").StartsWith("dayto-")));
 
-            if (holidayNodes == null)
+            if (!holidayNodes.Any())
             {
                 return new List<string> { "Свят не знайдено." };
             }


### PR DESCRIPTION
Changed the condition from checking if `holidayNodes` is `null` to using the `Any()` method to check if the collection is empty. This ensures proper handling of cases where `holidayNodes` is not `null` but contains no elements.

dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
