### PR TITLE
feat/SSAD-294: Add Hangfire for background jobs and token cleanup service

### DIFF
--- a/Streetcode/UserService.BLL/Interfaces/User/ITokenCleanupService.cs
+++ b/Streetcode/UserService.BLL/Interfaces/User/ITokenCleanupService.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UserService.BLL.Interfaces.User
+{
+    public interface ITokenCleanupService 
+    {
+        public Task RemoveExpiredRefreshTokensAsync();
+    }
+}

--- a/Streetcode/UserService.BLL/Services/User/TokenCleanupService.cs
+++ b/Streetcode/UserService.BLL/Services/User/TokenCleanupService.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using UserService.BLL.Interfaces.User;
+using UserEntity = UserService.DAL.Entities.Users.User;
+
+
+namespace UserService.BLL.Services.User
+{
+    public class TokenCleanupService : ITokenCleanupService
+    {
+        private readonly UserManager<UserEntity> _userManager;
+        private readonly ILogger<TokenCleanupService> _logger;
+
+        public TokenCleanupService(UserManager<UserEntity> userManager, ILogger<TokenCleanupService> logger)
+        {
+            _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task RemoveExpiredRefreshTokensAsync()
+        {
+            _logger.LogInformation("Starting cleanup of expired refresh tokens.");
+
+            // Отримання користувачів з простроченими токенами
+            var usersWithExpiredTokens = _userManager.Users
+                .Where(u => u.RefreshTokens.Any(t => t.RefreshTokenExpiryTime <= DateTime.UtcNow))
+                .ToList();
+
+            _logger.LogInformation("Found {UserCount} users with expired tokens.", usersWithExpiredTokens.Count);
+
+            foreach (var user in usersWithExpiredTokens)
+            {
+                var expiredTokens = user.RefreshTokens
+                    .Where(t => t.RefreshTokenExpiryTime <= DateTime.UtcNow)
+                    .ToList();
+
+                if (expiredTokens.Any())
+                {
+                    user.RefreshTokens.RemoveAll(t => expiredTokens.Contains(t));
+
+                    var updateResult = await _userManager.UpdateAsync(user);
+                    if (!updateResult.Succeeded)
+                    {
+                        _logger.LogError("Failed to update user {UserName} during cleanup.", user.UserName);
+                    }
+                    else
+                    {
+                        _logger.LogInformation("Removed {TokenCount} expired tokens for user {UserName}.", expiredTokens.Count, user.UserName);
+                    }
+                }
+            }
+
+            _logger.LogInformation("Completed cleanup of expired refresh tokens.");
+        }
+    }
+}

--- a/Streetcode/UserService.WebApi/UserService.WebApi.csproj
+++ b/Streetcode/UserService.WebApi/UserService.WebApi.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -12,6 +12,8 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.Identity.Mongo" Version="9.1.1" />
     <PackageReference Include="FluentResults" Version="3.16.0" />
+    <PackageReference Include="Hangfire" Version="1.8.17" />
+    <PackageReference Include="Hangfire.Mongo" Version="1.11.2" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.1.0" />


### PR DESCRIPTION

Introduce Hangfire for job scheduling in `Program.cs` with MongoDB storage. Add `ITokenCleanupService` and `TokenCleanupService` for removing expired refresh tokens. Configure Hangfire server and recurring job in `Program.cs`. Update `UserService.WebApi.csproj` with Hangfire package references.